### PR TITLE
Fixing accidental detection of require.js as common js

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -360,9 +360,11 @@ function parseZip(zip) {
 
 var fs, jszip;
 if(typeof JSZip !== "undefined") jszip = JSZip;
-if(typeof require !== "undefined") {
-	if(typeof jszip === 'undefined') jszip = require('./jszip').JSZip;
-	fs = require('fs');
+if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+        if(typeof jszip === 'undefined') jszip = require('./jszip').JSZip;
+        fs = require('fs');
+    }
 }
 
 function readSync(data, options) {


### PR DESCRIPTION
I changed to code to check for common js by looking for exports and module instead. Also, would it be possible to require fs inside the function where it's used?
