### PR TITLE
Support cells for the 'd' date type

### DIFF
--- a/bits/72_wsxml.js
+++ b/bits/72_wsxml.js
@@ -63,6 +63,11 @@ function parse_ws_xml(data, opts) {
 						case '1': case 'TRUE':  case "true":  case true:  p.v=true;  break;
 						default: throw "Unrecognized boolean: " + p.v;
 					} break;
+				case 'd':
+					var epoch = Date.parse(p.v);
+					p.v = (epoch - new Date(Date.UTC(1899, 11, 30))) / (24 * 60 * 60 * 1000);
+					p.t = 'n';
+					break;
 				/* in case of error, stick value in .raw */
 				case 'e': p.raw = RBErr[p.v]; break;
 				default: throw "Unrecognized cell type: " + p.t;

--- a/test.js
+++ b/test.js
@@ -201,3 +201,18 @@ describe('should have core properties and custom properties parsed', function() 
 		assert.equal(wb.Custprops.Counter, -3.14);
 	});
 });
+
+describe.skip('should parse a sheet with a d date cell', function() {
+	var wb, ws;
+	before(function() {
+		XLSX = require('./');
+		wb = XLSX.readFile('./test_files/xlsx-stream-d-date-cell.xlsx');
+		// wb = XLSX.readFile('./test_files/xlsx-stream-array.xlsx');
+		var sheetName = 'Sheet1';
+		ws = wb.Sheets[sheetName];
+	});
+	it('Must have read the date', function() {
+		var sheet = XLSX.utils.sheet_to_row_object_array(ws);
+		assert.equal(sheet[3]['てすと'], '2/14/14');
+	});
+});

--- a/xlsx.js
+++ b/xlsx.js
@@ -1349,6 +1349,11 @@ function parse_ws_xml(data, opts) {
 						case '1': case 'TRUE':  case "true":  case true:  p.v=true;  break;
 						default: throw "Unrecognized boolean: " + p.v;
 					} break;
+				case 'd':
+					var epoch = Date.parse(p.v);
+					p.v = (epoch - new Date(Date.UTC(1899, 11, 30))) / (24 * 60 * 60 * 1000);
+					p.t = 'n';
+					break;
 				/* in case of error, stick value in .raw */
 				case 'e': p.raw = RBErr[p.v]; break;
 				default: throw "Unrecognized cell type: " + p.t;


### PR DESCRIPTION
The library we are using to generate xlsx takes advantage of the 'd' type of cell that value is an ISO8601 date.
It seems that that type had yet to be encountered in the wild by js-xlsx.
Here is a quick patch to avoid crashing the whole sheet and extract a date.

I am adding comments to the code for the parts where I think we could improve it.

I am sending you the test file by email.
