### PR TITLE
Prevented crash on wbfactoid

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -3675,6 +3675,7 @@ function parse_wb_bin(data, opts) {
 			case 'BrtACBegin': break;
 			case 'BrtAbsPath15': break;
 			case 'BrtACEnd': break;
+			case 'BrtWbFactoid': break;
 			/*case 'BrtBookProtectionIso': break;*/
 			case 'BrtBookProtection': break;
 			case 'BrtBeginBookViews': break;


### PR DESCRIPTION
This was causing a crash when xlsb files specified factoids.  they're not being parse now, but at least the file gets loaded
