### PR TITLE
CSV export can now be cleansed from new lines and trailing spaces

### DIFF
--- a/bin/xlsx.njs
+++ b/bin/xlsx.njs
@@ -19,29 +19,30 @@ program
 	.option('-B, --xlsb', 'emit XLSB to <sheetname> or <file>.xlsb')
 	.option('-M, --xlsm', 'emit XLSM to <sheetname> or <file>.xlsm')
 	.option('-X, --xlsx', 'emit XLSX to <sheetname> or <file>.xlsx')
-	.option('-Y, --ods',  'emit ODS  to <sheetname> or <file>.ods')
-	.option('-8, --xls',  'emit XLS  to <sheetname> or <file>.xls (BIFF8)')
-	.option('-5, --biff5','emit XLS  to <sheetname> or <file>.xls (BIFF5)')
+	.option('-Y, --ods', 'emit ODS  to <sheetname> or <file>.ods')
+	.option('-8, --xls', 'emit XLS  to <sheetname> or <file>.xls (BIFF8)')
+	.option('-5, --biff5', 'emit XLS  to <sheetname> or <file>.xls (BIFF5)')
 	//.option('-4, --biff4','emit XLS  to <sheetname> or <file>.xls (BIFF4)')
 	//.option('-3, --biff3','emit XLS  to <sheetname> or <file>.xls (BIFF3)')
-	.option('-2, --biff2','emit XLS  to <sheetname> or <file>.xls (BIFF2)')
+	.option('-2, --biff2', 'emit XLS  to <sheetname> or <file>.xls (BIFF2)')
 	.option('-6, --xlml', 'emit SSML to <sheetname> or <file>.xls (2003 XML)')
 	.option('-T, --fods', 'emit FODS to <sheetname> or <file>.fods (Flat ODS)')
 
 	.option('-S, --formulae', 'emit list of values and formulae')
-	.option('-j, --json',     'emit formatted JSON (all fields text)')
-	.option('-J, --raw-js',   'emit raw JS object (raw numbers)')
-	.option('-A, --arrays',   'emit rows as JS objects (raw numbers)')
+	.option('-j, --json', 'emit formatted JSON (all fields text)')
+	.option('-J, --raw-js', 'emit raw JS object (raw numbers)')
+	.option('-A, --arrays', 'emit rows as JS objects (raw numbers)')
 	.option('-H, --html', 'emit HTML to <sheetname> or <file>.html')
-	.option('-D, --dif',  'emit DIF  to <sheetname> or <file>.dif (Lotus DIF)')
-	.option('-U, --dbf',  'emit DBF  to <sheetname> or <file>.dbf (MSVFP DBF)')
+	.option('-D, --dif', 'emit DIF  to <sheetname> or <file>.dif (Lotus DIF)')
+	.option('-U, --dbf', 'emit DBF  to <sheetname> or <file>.dbf (MSVFP DBF)')
 	.option('-K, --sylk', 'emit SYLK to <sheetname> or <file>.slk (Excel SYLK)')
-	.option('-P, --prn',  'emit PRN  to <sheetname> or <file>.prn (Lotus PRN)')
-	.option('-t, --txt',  'emit TXT  to <sheetname> or <file>.txt (UTF-8 TSV)')
-	.option('-r, --rtf',  'emit RTF  to <sheetname> or <file>.txt (Table RTF)')
+	.option('-P, --prn', 'emit PRN  to <sheetname> or <file>.prn (Lotus PRN)')
+	.option('-t, --txt', 'emit TXT  to <sheetname> or <file>.txt (UTF-8 TSV)')
+	.option('-r, --rtf', 'emit RTF  to <sheetname> or <file>.txt (Table RTF)')
 
 	.option('-F, --field-sep <sep>', 'CSV field separator', ",")
 	.option('-R, --row-sep <sep>', 'CSV row separator', "\n")
+	.option('--clean', 'CSV remove new lines from cells and trim them', "\n")
 	.option('-n, --sheet-rows <num>', 'Number of rows to process (0=all rows)')
 	.option('--sst', 'generate shared string table for XLS* formats')
 	.option('--compress', 'use compression when writing XLSX/M/B and ODS')
@@ -51,68 +52,68 @@ program
 	.option('--sparse', 'sparse mode')
 	.option('-q, --quiet', 'quiet mode');
 
-program.on('--help', function() {
+program.on('--help', function () {
 	console.log('  Default output format is CSV');
 	console.log('  Support email: dev@sheetjs.com');
-	console.log('  Web Demo: http://oss.sheetjs.com/js-'+n+'/');
+	console.log('  Web Demo: http://oss.sheetjs.com/js-' + n + '/');
 });
 
 /* flag, bookType, default ext */
 var workbook_formats = [
-	['xlsx',   'xlsx', 'xlsx'],
-	['xlsm',   'xlsm', 'xlsm'],
-	['xlsb',   'xlsb', 'xlsb'],
-	['xls',     'xls',  'xls'],
-	['biff5', 'biff5',  'xls'],
-	['ods',     'ods',  'ods'],
-	['fods',   'fods', 'fods']
+	['xlsx', 'xlsx', 'xlsx'],
+	['xlsm', 'xlsm', 'xlsm'],
+	['xlsb', 'xlsb', 'xlsb'],
+	['xls', 'xls', 'xls'],
+	['biff5', 'biff5', 'xls'],
+	['ods', 'ods', 'ods'],
+	['fods', 'fods', 'fods']
 ];
 var wb_formats_2 = [
-	['xlml',   'xlml', 'xls']
+	['xlml', 'xlml', 'xls']
 ];
 program.parse(process.argv);
 
 var filename = '', sheetname = '';
-if(program.args[0]) {
+if (program.args[0]) {
 	filename = program.args[0];
-	if(program.args[1]) sheetname = program.args[1];
+	if (program.args[1]) sheetname = program.args[1];
 }
-if(program.sheet) sheetname = program.sheet;
-if(program.file) filename = program.file;
+if (program.sheet) sheetname = program.sheet;
+if (program.file) filename = program.file;
 
-if(!filename) {
+if (!filename) {
 	console.error(n + ": must specify a filename");
 	process.exit(1);
 }
 /*:: if(filename) { */
-if(!fs.existsSync(filename)) {
+if (!fs.existsSync(filename)) {
 	console.error(n + ": " + filename + ": No such file or directory");
 	process.exit(2);
 }
 
 var opts = {}, wb/*:?Workbook*/;
-if(program.listSheets) opts.bookSheets = true;
-if(program.sheetRows) opts.sheetRows = program.sheetRows;
-if(program.password) opts.password = program.password;
+if (program.listSheets) opts.bookSheets = true;
+if (program.sheetRows) opts.sheetRows = program.sheetRows;
+if (program.password) opts.password = program.password;
 var seen = false;
 function wb_fmt() {
 	seen = true;
 	opts.cellFormula = true;
 	opts.cellNF = true;
-	if(program.output) sheetname = program.output;
+	if (program.output) sheetname = program.output;
 }
 function isfmt(m/*:string*/)/*:boolean*/ {
-	if(!program.output) return false;
+	if (!program.output) return false;
 	var t = m.charAt(0) === "." ? m : "." + m;
 	return program.output.slice(-t.length) === t;
 }
-workbook_formats.forEach(function(m) { if(program[m[0]] || isfmt(m[0])) { wb_fmt(); } });
-wb_formats_2.forEach(function(m) { if(program[m[0]] || isfmt(m[0])) { wb_fmt(); } });
-if(seen) {
-} else if(program.formulae) opts.cellFormula = true;
+workbook_formats.forEach(function (m) { if (program[m[0]] || isfmt(m[0])) { wb_fmt(); } });
+wb_formats_2.forEach(function (m) { if (program[m[0]] || isfmt(m[0])) { wb_fmt(); } });
+if (seen) {
+} else if (program.formulae) opts.cellFormula = true;
 else opts.cellFormula = false;
 
-if(program.all) {
+if (program.all) {
 	opts.cellFormula = true;
 	opts.bookVBA = true;
 	opts.cellNF = true;
@@ -121,58 +122,62 @@ if(program.all) {
 	opts.sheetStubs = true;
 	opts.cellDates = true;
 }
-if(program.sparse) opts.dense = false; else opts.dense = true;
+if (program.sparse) opts.dense = false; else opts.dense = true;
 
-if(program.dev) {
+if (program.dev) {
 	opts.WTF = true;
 	wb = X.readFile(filename, opts);
 } else try {
 	wb = X.readFile(filename, opts);
-} catch(e) {
+} catch (e) {
 	var msg = (program.quiet) ? "" : n + ": error parsing ";
 	msg += filename + ": " + e;
 	console.error(msg);
 	process.exit(3);
 }
-if(program.read) process.exit(0);
+if (program.read) process.exit(0);
 
 /*::   if(wb) { */
-if(program.listSheets) {
-	console.log((wb.SheetNames||[]).join("\n"));
+if (program.listSheets) {
+	console.log((wb.SheetNames || []).join("\n"));
 	process.exit(0);
 }
 
-var wopts = ({WTF:opts.WTF, bookSST:program.sst}/*:any*/);
-if(program.compress) wopts.compression = true;
+var wopts = ({ WTF: opts.WTF, bookSST: program.sst }/*:any*/);
+if (program.compress) wopts.compression = true;
 
 /* full workbook formats */
-workbook_formats.forEach(function(m) { if(program[m[0]] || isfmt(m[0])) {
+workbook_formats.forEach(function (m) {
+	if (program[m[0]] || isfmt(m[0])) {
 		wopts.bookType = m[1];
 		X.writeFile(wb, program.output || sheetname || ((filename || "") + "." + m[2]), wopts);
 		process.exit(0);
-} });
+	}
+});
 
-wb_formats_2.forEach(function(m) { if(program[m[0]] || isfmt(m[0])) {
+wb_formats_2.forEach(function (m) {
+	if (program[m[0]] || isfmt(m[0])) {
 		wopts.bookType = m[1];
 		X.writeFile(wb, program.output || sheetname || ((filename || "") + "." + m[2]), wopts);
 		process.exit(0);
-} });
+	}
+});
 
 var target_sheet = sheetname || '';
-if(target_sheet === '') {
-	if(program.sheetIndex < (wb.SheetNames||[]).length) target_sheet = wb.SheetNames[program.sheetIndex];
-	else target_sheet = (wb.SheetNames||[""])[0];
+if (target_sheet === '') {
+	if (program.sheetIndex < (wb.SheetNames || []).length) target_sheet = wb.SheetNames[program.sheetIndex];
+	else target_sheet = (wb.SheetNames || [""])[0];
 }
 
 var ws;
 try {
 	ws = wb.Sheets[target_sheet];
-	if(!ws) {
+	if (!ws) {
 		console.error("Sheet " + target_sheet + " cannot be found");
 		process.exit(3);
 	}
-} catch(e) {
-	console.error(n + ": error parsing "+filename+" "+target_sheet+": " + e);
+} catch (e) {
+	console.error(n + ": error parsing " + filename + " " + target_sheet + ": " + e);
 	process.exit(4);
 }
 
@@ -189,27 +194,29 @@ try {
 	['txt', '.txt'],
 	['dbf', '.dbf'],
 	['dif', '.dif']
-].forEach(function(m) { if(program[m[0]] || isfmt(m[1])) {
+].forEach(function (m) {
+	if (program[m[0]] || isfmt(m[1])) {
 		wopts.bookType = m[0];
 		X.writeFile(wb, program.output || sheetname || ((filename || "") + m[1]), wopts);
 		process.exit(0);
-} });
+	}
+});
 
 var oo = "", strm = false;
-if(!program.quiet) console.error(target_sheet);
-if(program.formulae) oo = X.utils.sheet_to_formulae(ws).join("\n");
-else if(program.json) oo = JSON.stringify(X.utils.sheet_to_json(ws));
-else if(program.rawJs) oo = JSON.stringify(X.utils.sheet_to_json(ws,{raw:true}));
-else if(program.arrays) oo = JSON.stringify(X.utils.sheet_to_json(ws,{raw:true, header:1}));
+if (!program.quiet) console.error(target_sheet);
+if (program.formulae) oo = X.utils.sheet_to_formulae(ws).join("\n");
+else if (program.json) oo = JSON.stringify(X.utils.sheet_to_json(ws));
+else if (program.rawJs) oo = JSON.stringify(X.utils.sheet_to_json(ws, { raw: true }));
+else if (program.arrays) oo = JSON.stringify(X.utils.sheet_to_json(ws, { raw: true, header: 1 }));
 else {
 	strm = true;
-	var stream = X.stream.to_csv(ws, {FS:program.fieldSep, RS:program.rowSep});
-	if(program.output) stream.pipe(fs.createWriteStream(program.output));
+	var stream = X.stream.to_csv(ws, { FS: program.fieldSep, RS: program.rowSep, clean: program.clean });
+	if (program.output) stream.pipe(fs.createWriteStream(program.output));
 	else stream.pipe(process.stdout);
 }
 
-if(!strm) {
-	if(program.output) fs.writeFileSync(program.output, oo);
+if (!strm) {
+	if (program.output) fs.writeFileSync(program.output, oo);
 	else console.log(oo);
 }
 /*::   } */

--- a/bits/90_utils.js
+++ b/bits/90_utils.js
@@ -1,39 +1,39 @@
 function sheet_to_json(sheet/*:Worksheet*/, opts/*:?Sheet2JSONOpts*/) {
-	if(sheet == null || sheet["!ref"] == null) return [];
-	var val = {t:'n',v:0}, header = 0, offset = 1, hdr/*:Array<any>*/ = [], isempty = true, v=0, vv="";
-	var r = {s:{r:0,c:0},e:{r:0,c:0}};
+	if (sheet == null || sheet["!ref"] == null) return [];
+	var val = { t: 'n', v: 0 }, header = 0, offset = 1, hdr/*:Array<any>*/ = [], isempty = true, v = 0, vv = "";
+	var r = { s: { r: 0, c: 0 }, e: { r: 0, c: 0 } };
 	var o = opts || {};
 	var raw = o.raw;
 	var defval = o.defval;
 	var range = o.range != null ? o.range : sheet["!ref"];
-	if(o.header === 1) header = 1;
-	else if(o.header === "A") header = 2;
-	else if(Array.isArray(o.header)) header = 3;
-	switch(typeof range) {
+	if (o.header === 1) header = 1;
+	else if (o.header === "A") header = 2;
+	else if (Array.isArray(o.header)) header = 3;
+	switch (typeof range) {
 		case 'string': r = safe_decode_range(range); break;
 		case 'number': r = safe_decode_range(sheet["!ref"]); r.s.r = range; break;
 		default: r = range;
 	}
-	if(header > 0) offset = 0;
+	if (header > 0) offset = 0;
 	var rr = encode_row(r.s.r);
 	var cols/*:Array<string>*/ = [];
 	var out/*:Array<any>*/ = [];
 	var outi = 0, counter = 0;
 	var dense = Array.isArray(sheet);
 	var R = r.s.r, C = 0, CC = 0;
-	if(dense && !sheet[R]) sheet[R] = [];
-	for(C = r.s.c; C <= r.e.c; ++C) {
+	if (dense && !sheet[R]) sheet[R] = [];
+	for (C = r.s.c; C <= r.e.c; ++C) {
 		cols[C] = encode_col(C);
 		val = dense ? sheet[R][C] : sheet[cols[C] + rr];
-		switch(header) {
+		switch (header) {
 			case 1: hdr[C] = C - r.s.c; break;
 			case 2: hdr[C] = cols[C]; break;
 			case 3: hdr[C] = o.header[C - r.s.c]; break;
 			default:
-				if(val == null) continue;
+				if (val == null) continue;
 				vv = v = format_cell(val, null, o);
 				counter = 0;
-				for(CC = 0; CC < hdr.length; ++CC) if(hdr[CC] == vv) vv = v + "_" + (++counter);
+				for (CC = 0; CC < hdr.length; ++CC) if (hdr[CC] == vv) vv = v + "_" + (++counter);
 				hdr[C] = vv;
 		}
 	}
@@ -41,38 +41,38 @@ function sheet_to_json(sheet/*:Worksheet*/, opts/*:?Sheet2JSONOpts*/) {
 	for (R = r.s.r + offset; R <= r.e.r; ++R) {
 		rr = encode_row(R);
 		isempty = true;
-		if(header === 1) row = [];
+		if (header === 1) row = [];
 		else {
 			row = {};
-			if(Object.defineProperty) try { Object.defineProperty(row, '__rowNum__', {value:R, enumerable:false}); } catch(e) { row.__rowNum__ = R; }
+			if (Object.defineProperty) try { Object.defineProperty(row, '__rowNum__', { value: R, enumerable: false }); } catch (e) { row.__rowNum__ = R; }
 			else row.__rowNum__ = R;
 		}
-		if(!dense || sheet[R]) for (C = r.s.c; C <= r.e.c; ++C) {
+		if (!dense || sheet[R]) for (C = r.s.c; C <= r.e.c; ++C) {
 			val = dense ? sheet[R][C] : sheet[cols[C] + rr];
-			if(val === undefined || val.t === undefined) {
-				if(defval === undefined) continue;
-				if(hdr[C] != null) { row[hdr[C]] = defval; isempty = false; }
+			if (val === undefined || val.t === undefined) {
+				if (defval === undefined) continue;
+				if (hdr[C] != null) { row[hdr[C]] = defval; isempty = false; }
 				continue;
 			}
 			v = val.v;
-			switch(val.t){
-				case 'z': if(v == null) break; continue;
+			switch (val.t) {
+				case 'z': if (v == null) break; continue;
 				case 'e': continue;
 				case 's': case 'd': case 'b': case 'n': break;
 				default: throw new Error('unrecognized type ' + val.t);
 			}
-			if(hdr[C] != null) {
-				if(v == null) {
-					if(defval !== undefined) row[hdr[C]] = defval;
-					else if(raw && v === null) row[hdr[C]] = null;
+			if (hdr[C] != null) {
+				if (v == null) {
+					if (defval !== undefined) row[hdr[C]] = defval;
+					else if (raw && v === null) row[hdr[C]] = null;
 					else continue;
 				} else {
-					row[hdr[C]] = raw ? v : format_cell(val,v,o);
+					row[hdr[C]] = raw ? v : format_cell(val, v, o);
 				}
 				isempty = false;
 			}
 		}
-		if((isempty === false) || (header === 1 ? o.blankrows !== false : !!o.blankrows)) out[outi++] = row;
+		if ((isempty === false) || (header === 1 ? o.blankrows !== false : !!o.blankrows)) out[outi++] = row;
 	}
 	out.length = outi;
 	return out;
@@ -82,44 +82,48 @@ var qreg = /"/g;
 function make_csv_row(sheet/*:Worksheet*/, r/*:Range*/, R/*:number*/, cols/*:Array<string>*/, fs/*:number*/, rs/*:number*/, FS/*:string*/, o/*:Sheet2CSVOpts*/)/*:?string*/ {
 	var isempty = true;
 	var row/*:Array<string>*/ = [], txt = "", rr = encode_row(R);
-	for(var C = r.s.c; C <= r.e.c; ++C) {
+	for (var C = r.s.c; C <= r.e.c; ++C) {
 		if (!cols[C]) continue;
-		var val = o.dense ? (sheet[R]||[])[C]: sheet[cols[C] + rr];
-		if(val == null) txt = "";
-		else if(val.v != null) {
+		var val = o.dense ? (sheet[R] || [])[C] : sheet[cols[C] + rr];
+		if (val == null) txt = "";
+		else if (val.v != null) {
 			isempty = false;
-			txt = ''+format_cell(val, null, o);
-			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
-			if(txt == "ID") txt = '"ID"';
-		} else if(val.f != null && !val.F) {
+			txt = '' + format_cell(val, null, o);
+			for (var i = 0, cc = 0; i !== txt.length; ++i) if ((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34) { txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
+			if (o.clean) {
+				txt = txt.replace(/\s\s+/g, ' ');
+				txt = txt.trim();
+			}
+			if (txt == "ID") txt = '"ID"';
+		} else if (val.f != null && !val.F) {
 			isempty = false;
-			txt = '=' + val.f; if(txt.indexOf(",") >= 0) txt = '"' + txt.replace(qreg, '""') + '"';
+			txt = '=' + val.f; if (txt.indexOf(",") >= 0) txt = '"' + txt.replace(qreg, '""') + '"';
 		} else txt = "";
 		/* NOTE: Excel CSV does not support array formulae */
 		row.push(txt);
 	}
-	if(o.blankrows === false && isempty) return null;
+	if (o.blankrows === false && isempty) return null;
 	return row.join(FS);
 }
 
 function sheet_to_csv(sheet/*:Worksheet*/, opts/*:?Sheet2CSVOpts*/)/*:string*/ {
 	var out = [];
 	var o = opts == null ? {} : opts;
-	if(sheet == null || sheet["!ref"] == null) return "";
+	if (sheet == null || sheet["!ref"] == null) return "";
 	var r = safe_decode_range(sheet["!ref"]);
 	var FS = o.FS !== undefined ? o.FS : ",", fs = FS.charCodeAt(0);
 	var RS = o.RS !== undefined ? o.RS : "\n", rs = RS.charCodeAt(0);
-	var endregex = new RegExp((FS=="|" ? "\\|" : FS)+"+$");
+	var endregex = new RegExp((FS == "|" ? "\\|" : FS) + "+$");
 	var row = "", cols = [];
 	o.dense = Array.isArray(sheet);
 	var colInfos = o.skipHidden && sheet["!cols"] || [];
 	var rowInfos = o.skipHidden && sheet["!rows"] || [];
-	for(var C = r.s.c; C <= r.e.c; ++C) if (!((colInfos[C]||{}).hidden)) cols[C] = encode_col(C);
-	for(var R = r.s.r; R <= r.e.r; ++R) {
-		if ((rowInfos[R]||{}).hidden) continue;
+	for (var C = r.s.c; C <= r.e.c; ++C) if (!((colInfos[C] || {}).hidden)) cols[C] = encode_col(C);
+	for (var R = r.s.r; R <= r.e.r; ++R) {
+		if ((rowInfos[R] || {}).hidden) continue;
 		row = make_csv_row(sheet, r, R, cols, fs, rs, FS, o);
-		if(row == null) { continue; }
-		if(o.strip) row = row.replace(endregex,"");
+		if (row == null) { continue; }
+		if (o.strip) row = row.replace(endregex, "");
 		out.push(row + RS);
 	}
 	delete o.dense;
@@ -127,41 +131,41 @@ function sheet_to_csv(sheet/*:Worksheet*/, opts/*:?Sheet2CSVOpts*/)/*:string*/ {
 }
 
 function sheet_to_txt(sheet/*:Worksheet*/, opts/*:?Sheet2CSVOpts*/) {
-	if(!opts) opts = {}; opts.FS = "\t"; opts.RS = "\n";
+	if (!opts) opts = {}; opts.FS = "\t"; opts.RS = "\n";
 	var s = sheet_to_csv(sheet, opts);
-	if(typeof cptable == 'undefined' || opts.type == 'string') return s;
+	if (typeof cptable == 'undefined' || opts.type == 'string') return s;
 	var o = cptable.utils.encode(1200, s, 'str');
 	return "\xff\xfe" + o;
 }
 
 function sheet_to_formulae(sheet/*:Worksheet*/)/*:Array<string>*/ {
-	var y = "", x, val="";
-	if(sheet == null || sheet["!ref"] == null) return [];
+	var y = "", x, val = "";
+	if (sheet == null || sheet["!ref"] == null) return [];
 	var r = safe_decode_range(sheet['!ref']), rr = "", cols = [], C;
 	var cmds/*:Array<string>*/ = [];
 	var dense = Array.isArray(sheet);
-	for(C = r.s.c; C <= r.e.c; ++C) cols[C] = encode_col(C);
-	for(var R = r.s.r; R <= r.e.r; ++R) {
+	for (C = r.s.c; C <= r.e.c; ++C) cols[C] = encode_col(C);
+	for (var R = r.s.r; R <= r.e.r; ++R) {
 		rr = encode_row(R);
-		for(C = r.s.c; C <= r.e.c; ++C) {
+		for (C = r.s.c; C <= r.e.c; ++C) {
 			y = cols[C] + rr;
-			x = dense ? (sheet[R]||[])[C] : sheet[y];
+			x = dense ? (sheet[R] || [])[C] : sheet[y];
 			val = "";
-			if(x === undefined) continue;
-			else if(x.F != null) {
+			if (x === undefined) continue;
+			else if (x.F != null) {
 				y = x.F;
-				if(!x.f) continue;
+				if (!x.f) continue;
 				val = x.f;
-				if(y.indexOf(":") == -1) y = y + ":" + y;
+				if (y.indexOf(":") == -1) y = y + ":" + y;
 			}
-			if(x.f != null) val = x.f;
-			else if(x.t == 'z') continue;
-			else if(x.t == 'n' && x.v != null) val = "" + x.v;
-			else if(x.t == 'b') val = x.v ? "TRUE" : "FALSE";
-			else if(x.w !== undefined) val = "'" + x.w;
-			else if(x.v === undefined) continue;
-			else if(x.t == 's') val = "'" + x.v;
-			else val = ""+x.v;
+			if (x.f != null) val = x.f;
+			else if (x.t == 'z') continue;
+			else if (x.t == 'n' && x.v != null) val = "" + x.v;
+			else if (x.t == 'b') val = x.v ? "TRUE" : "FALSE";
+			else if (x.w !== undefined) val = "'" + x.w;
+			else if (x.v === undefined) continue;
+			else if (x.t == 's') val = "'" + x.v;
+			else val = "" + x.v;
 			cmds[cmds.length] = y + "=" + val;
 		}
 	}
@@ -172,29 +176,29 @@ function json_to_sheet(js/*:Array<any>*/, opts)/*:Worksheet*/ {
 	var o = opts || {};
 	var ws = ({}/*:any*/);
 	var cell/*:Cell*/;
-	var range/*:Range*/ = ({s: {c:0, r:0}, e: {c:0, r:js.length}}/*:any*/);
+	var range/*:Range*/ = ({ s: { c: 0, r: 0 }, e: { c: 0, r: js.length } }/*:any*/);
 	var hdr = o.header || [], C = 0;
 
 	js.forEach(function (JS, R) {
-		keys(JS).filter(function(x) { return JS.hasOwnProperty(x); }).forEach(function(k) {
-			if((C=hdr.indexOf(k)) == -1) hdr[C=hdr.length] = k;
+		keys(JS).filter(function (x) { return JS.hasOwnProperty(x); }).forEach(function (k) {
+			if ((C = hdr.indexOf(k)) == -1) hdr[C = hdr.length] = k;
 			var v = JS[k];
 			var t = 'z';
 			var z = "";
-			if(typeof v == 'number') t = 'n';
-			else if(typeof v == 'boolean') t = 'b';
-			else if(typeof v == 'string') t = 's';
-			else if(v instanceof Date) {
+			if (typeof v == 'number') t = 'n';
+			else if (typeof v == 'boolean') t = 'b';
+			else if (typeof v == 'string') t = 's';
+			else if (v instanceof Date) {
 				t = 'd';
-				if(!o.cellDates) { t = 'n'; v = datenum(v); }
+				if (!o.cellDates) { t = 'n'; v = datenum(v); }
 				z = o.dateNF || SSF._table[14];
 			}
-			ws[encode_cell({c:C,r:R+1})] = cell = ({t:t, v:v}/*:any*/);
-			if(z) cell.z = z;
+			ws[encode_cell({ c: C, r: R + 1 })] = cell = ({ t: t, v: v }/*:any*/);
+			if (z) cell.z = z;
 		});
 	});
 	range.e.c = hdr.length - 1;
-	for(C = 0; C < hdr.length; ++C) ws[encode_col(C) + "1"] = {t:'s', v:hdr[C]};
+	for (C = 0; C < hdr.length; ++C) ws[encode_col(C) + "1"] = { t: 's', v: hdr[C] };
 	ws['!ref'] = encode_range(range);
 	return ws;
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,20 @@
 	"version": "0.11.7",
 	"author": "sheetjs",
 	"description": "SheetJS Spreadsheet data parser and writer",
-	"keywords": [ "excel", "xls", "xlsx", "xlsb", "xlsm", "ods", "csv", "dbf", "dif", "sylk", "office", "spreadsheet" ],
+	"keywords": [
+		"excel",
+		"xls",
+		"xlsx",
+		"xlsb",
+		"xlsm",
+		"ods",
+		"csv",
+		"dbf",
+		"dif",
+		"sylk",
+		"office",
+		"spreadsheet"
+	],
 	"bin": {
 		"xlsx": "./bin/xlsx.njs"
 	},
@@ -35,7 +48,10 @@
 		"dtslint": "^0.1.2",
 		"typescript": "2.2.0"
 	},
-	"repository": { "type":"git", "url":"git://github.com/SheetJS/js-xlsx.git" },
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/SheetJS/js-xlsx.git"
+	},
 	"scripts": {
 		"pretest": "git submodule init && git submodule update",
 		"test": "make travis",
@@ -48,9 +64,18 @@
 			"pattern": "xlsx.js"
 		}
 	},
-	"alex": { "allow": ["wtf", "holes"] },
+	"alex": {
+		"allow": [
+			"wtf",
+			"holes"
+		]
+	},
 	"homepage": "http://sheetjs.com/opensource",
-	"bugs": { "url": "https://github.com/SheetJS/js-xlsx/issues" },
+	"bugs": {
+		"url": "https://github.com/SheetJS/js-xlsx/issues"
+	},
 	"license": "Apache-2.0",
-	"engines": { "node": ">=0.8" }
+	"engines": {
+		"node": ">=0.8"
+	}
 }

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -18640,41 +18640,41 @@ function writeFileAsync(filename/*:string*/, wb/*:Workbook*/, opts/*:?WriteFileO
 	return _fs.writeFile(filename, writeSync(wb, o), _cb);
 }
 function sheet_to_json(sheet/*:Worksheet*/, opts/*:?Sheet2JSONOpts*/) {
-	if(sheet == null || sheet["!ref"] == null) return [];
-	var val = {t:'n',v:0}, header = 0, offset = 1, hdr/*:Array<any>*/ = [], isempty = true, v=0, vv="";
-	var r = {s:{r:0,c:0},e:{r:0,c:0}};
+	if (sheet == null || sheet["!ref"] == null) return [];
+	var val = { t: 'n', v: 0 }, header = 0, offset = 1, hdr/*:Array<any>*/ = [], isempty = true, v = 0, vv = "";
+	var r = { s: { r: 0, c: 0 }, e: { r: 0, c: 0 } };
 	var o = opts || {};
 	var raw = o.raw;
 	var defval = o.defval;
 	var range = o.range != null ? o.range : sheet["!ref"];
-	if(o.header === 1) header = 1;
-	else if(o.header === "A") header = 2;
-	else if(Array.isArray(o.header)) header = 3;
-	switch(typeof range) {
+	if (o.header === 1) header = 1;
+	else if (o.header === "A") header = 2;
+	else if (Array.isArray(o.header)) header = 3;
+	switch (typeof range) {
 		case 'string': r = safe_decode_range(range); break;
 		case 'number': r = safe_decode_range(sheet["!ref"]); r.s.r = range; break;
 		default: r = range;
 	}
-	if(header > 0) offset = 0;
+	if (header > 0) offset = 0;
 	var rr = encode_row(r.s.r);
 	var cols/*:Array<string>*/ = [];
 	var out/*:Array<any>*/ = [];
 	var outi = 0, counter = 0;
 	var dense = Array.isArray(sheet);
 	var R = r.s.r, C = 0, CC = 0;
-	if(dense && !sheet[R]) sheet[R] = [];
-	for(C = r.s.c; C <= r.e.c; ++C) {
+	if (dense && !sheet[R]) sheet[R] = [];
+	for (C = r.s.c; C <= r.e.c; ++C) {
 		cols[C] = encode_col(C);
 		val = dense ? sheet[R][C] : sheet[cols[C] + rr];
-		switch(header) {
+		switch (header) {
 			case 1: hdr[C] = C - r.s.c; break;
 			case 2: hdr[C] = cols[C]; break;
 			case 3: hdr[C] = o.header[C - r.s.c]; break;
 			default:
-				if(val == null) continue;
+				if (val == null) continue;
 				vv = v = format_cell(val, null, o);
 				counter = 0;
-				for(CC = 0; CC < hdr.length; ++CC) if(hdr[CC] == vv) vv = v + "_" + (++counter);
+				for (CC = 0; CC < hdr.length; ++CC) if (hdr[CC] == vv) vv = v + "_" + (++counter);
 				hdr[C] = vv;
 		}
 	}
@@ -18682,38 +18682,38 @@ function sheet_to_json(sheet/*:Worksheet*/, opts/*:?Sheet2JSONOpts*/) {
 	for (R = r.s.r + offset; R <= r.e.r; ++R) {
 		rr = encode_row(R);
 		isempty = true;
-		if(header === 1) row = [];
+		if (header === 1) row = [];
 		else {
 			row = {};
-			if(Object.defineProperty) try { Object.defineProperty(row, '__rowNum__', {value:R, enumerable:false}); } catch(e) { row.__rowNum__ = R; }
+			if (Object.defineProperty) try { Object.defineProperty(row, '__rowNum__', { value: R, enumerable: false }); } catch (e) { row.__rowNum__ = R; }
 			else row.__rowNum__ = R;
 		}
-		if(!dense || sheet[R]) for (C = r.s.c; C <= r.e.c; ++C) {
+		if (!dense || sheet[R]) for (C = r.s.c; C <= r.e.c; ++C) {
 			val = dense ? sheet[R][C] : sheet[cols[C] + rr];
-			if(val === undefined || val.t === undefined) {
-				if(defval === undefined) continue;
-				if(hdr[C] != null) { row[hdr[C]] = defval; isempty = false; }
+			if (val === undefined || val.t === undefined) {
+				if (defval === undefined) continue;
+				if (hdr[C] != null) { row[hdr[C]] = defval; isempty = false; }
 				continue;
 			}
 			v = val.v;
-			switch(val.t){
-				case 'z': if(v == null) break; continue;
+			switch (val.t) {
+				case 'z': if (v == null) break; continue;
 				case 'e': continue;
 				case 's': case 'd': case 'b': case 'n': break;
 				default: throw new Error('unrecognized type ' + val.t);
 			}
-			if(hdr[C] != null) {
-				if(v == null) {
-					if(defval !== undefined) row[hdr[C]] = defval;
-					else if(raw && v === null) row[hdr[C]] = null;
+			if (hdr[C] != null) {
+				if (v == null) {
+					if (defval !== undefined) row[hdr[C]] = defval;
+					else if (raw && v === null) row[hdr[C]] = null;
 					else continue;
 				} else {
-					row[hdr[C]] = raw ? v : format_cell(val,v,o);
+					row[hdr[C]] = raw ? v : format_cell(val, v, o);
 				}
 				isempty = false;
 			}
 		}
-		if((isempty === false) || (header === 1 ? o.blankrows !== false : !!o.blankrows)) out[outi++] = row;
+		if ((isempty === false) || (header === 1 ? o.blankrows !== false : !!o.blankrows)) out[outi++] = row;
 	}
 	out.length = outi;
 	return out;
@@ -18723,44 +18723,48 @@ var qreg = /"/g;
 function make_csv_row(sheet/*:Worksheet*/, r/*:Range*/, R/*:number*/, cols/*:Array<string>*/, fs/*:number*/, rs/*:number*/, FS/*:string*/, o/*:Sheet2CSVOpts*/)/*:?string*/ {
 	var isempty = true;
 	var row/*:Array<string>*/ = [], txt = "", rr = encode_row(R);
-	for(var C = r.s.c; C <= r.e.c; ++C) {
+	for (var C = r.s.c; C <= r.e.c; ++C) {
 		if (!cols[C]) continue;
-		var val = o.dense ? (sheet[R]||[])[C]: sheet[cols[C] + rr];
-		if(val == null) txt = "";
-		else if(val.v != null) {
+		var val = o.dense ? (sheet[R] || [])[C] : sheet[cols[C] + rr];
+		if (val == null) txt = "";
+		else if (val.v != null) {
 			isempty = false;
-			txt = ''+format_cell(val, null, o);
-			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
-			if(txt == "ID") txt = '"ID"';
-		} else if(val.f != null && !val.F) {
+			txt = '' + format_cell(val, null, o);
+			for (var i = 0, cc = 0; i !== txt.length; ++i) if ((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34) { txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
+			if (o.clean) {
+				txt = txt.replace(/\s\s+/g, ' ');
+				txt = txt.trim();
+			}
+			if (txt == "ID") txt = '"ID"';
+		} else if (val.f != null && !val.F) {
 			isempty = false;
-			txt = '=' + val.f; if(txt.indexOf(",") >= 0) txt = '"' + txt.replace(qreg, '""') + '"';
+			txt = '=' + val.f; if (txt.indexOf(",") >= 0) txt = '"' + txt.replace(qreg, '""') + '"';
 		} else txt = "";
 		/* NOTE: Excel CSV does not support array formulae */
 		row.push(txt);
 	}
-	if(o.blankrows === false && isempty) return null;
+	if (o.blankrows === false && isempty) return null;
 	return row.join(FS);
 }
 
 function sheet_to_csv(sheet/*:Worksheet*/, opts/*:?Sheet2CSVOpts*/)/*:string*/ {
 	var out = [];
 	var o = opts == null ? {} : opts;
-	if(sheet == null || sheet["!ref"] == null) return "";
+	if (sheet == null || sheet["!ref"] == null) return "";
 	var r = safe_decode_range(sheet["!ref"]);
 	var FS = o.FS !== undefined ? o.FS : ",", fs = FS.charCodeAt(0);
 	var RS = o.RS !== undefined ? o.RS : "\n", rs = RS.charCodeAt(0);
-	var endregex = new RegExp((FS=="|" ? "\\|" : FS)+"+$");
+	var endregex = new RegExp((FS == "|" ? "\\|" : FS) + "+$");
 	var row = "", cols = [];
 	o.dense = Array.isArray(sheet);
 	var colInfos = o.skipHidden && sheet["!cols"] || [];
 	var rowInfos = o.skipHidden && sheet["!rows"] || [];
-	for(var C = r.s.c; C <= r.e.c; ++C) if (!((colInfos[C]||{}).hidden)) cols[C] = encode_col(C);
-	for(var R = r.s.r; R <= r.e.r; ++R) {
-		if ((rowInfos[R]||{}).hidden) continue;
+	for (var C = r.s.c; C <= r.e.c; ++C) if (!((colInfos[C] || {}).hidden)) cols[C] = encode_col(C);
+	for (var R = r.s.r; R <= r.e.r; ++R) {
+		if ((rowInfos[R] || {}).hidden) continue;
 		row = make_csv_row(sheet, r, R, cols, fs, rs, FS, o);
-		if(row == null) { continue; }
-		if(o.strip) row = row.replace(endregex,"");
+		if (row == null) { continue; }
+		if (o.strip) row = row.replace(endregex, "");
 		out.push(row + RS);
 	}
 	delete o.dense;
@@ -18768,41 +18772,41 @@ function sheet_to_csv(sheet/*:Worksheet*/, opts/*:?Sheet2CSVOpts*/)/*:string*/ {
 }
 
 function sheet_to_txt(sheet/*:Worksheet*/, opts/*:?Sheet2CSVOpts*/) {
-	if(!opts) opts = {}; opts.FS = "\t"; opts.RS = "\n";
+	if (!opts) opts = {}; opts.FS = "\t"; opts.RS = "\n";
 	var s = sheet_to_csv(sheet, opts);
-	if(typeof cptable == 'undefined' || opts.type == 'string') return s;
+	if (typeof cptable == 'undefined' || opts.type == 'string') return s;
 	var o = cptable.utils.encode(1200, s, 'str');
 	return "\xff\xfe" + o;
 }
 
 function sheet_to_formulae(sheet/*:Worksheet*/)/*:Array<string>*/ {
-	var y = "", x, val="";
-	if(sheet == null || sheet["!ref"] == null) return [];
+	var y = "", x, val = "";
+	if (sheet == null || sheet["!ref"] == null) return [];
 	var r = safe_decode_range(sheet['!ref']), rr = "", cols = [], C;
 	var cmds/*:Array<string>*/ = [];
 	var dense = Array.isArray(sheet);
-	for(C = r.s.c; C <= r.e.c; ++C) cols[C] = encode_col(C);
-	for(var R = r.s.r; R <= r.e.r; ++R) {
+	for (C = r.s.c; C <= r.e.c; ++C) cols[C] = encode_col(C);
+	for (var R = r.s.r; R <= r.e.r; ++R) {
 		rr = encode_row(R);
-		for(C = r.s.c; C <= r.e.c; ++C) {
+		for (C = r.s.c; C <= r.e.c; ++C) {
 			y = cols[C] + rr;
-			x = dense ? (sheet[R]||[])[C] : sheet[y];
+			x = dense ? (sheet[R] || [])[C] : sheet[y];
 			val = "";
-			if(x === undefined) continue;
-			else if(x.F != null) {
+			if (x === undefined) continue;
+			else if (x.F != null) {
 				y = x.F;
-				if(!x.f) continue;
+				if (!x.f) continue;
 				val = x.f;
-				if(y.indexOf(":") == -1) y = y + ":" + y;
+				if (y.indexOf(":") == -1) y = y + ":" + y;
 			}
-			if(x.f != null) val = x.f;
-			else if(x.t == 'z') continue;
-			else if(x.t == 'n' && x.v != null) val = "" + x.v;
-			else if(x.t == 'b') val = x.v ? "TRUE" : "FALSE";
-			else if(x.w !== undefined) val = "'" + x.w;
-			else if(x.v === undefined) continue;
-			else if(x.t == 's') val = "'" + x.v;
-			else val = ""+x.v;
+			if (x.f != null) val = x.f;
+			else if (x.t == 'z') continue;
+			else if (x.t == 'n' && x.v != null) val = "" + x.v;
+			else if (x.t == 'b') val = x.v ? "TRUE" : "FALSE";
+			else if (x.w !== undefined) val = "'" + x.w;
+			else if (x.v === undefined) continue;
+			else if (x.t == 's') val = "'" + x.v;
+			else val = "" + x.v;
 			cmds[cmds.length] = y + "=" + val;
 		}
 	}
@@ -18813,29 +18817,29 @@ function json_to_sheet(js/*:Array<any>*/, opts)/*:Worksheet*/ {
 	var o = opts || {};
 	var ws = ({}/*:any*/);
 	var cell/*:Cell*/;
-	var range/*:Range*/ = ({s: {c:0, r:0}, e: {c:0, r:js.length}}/*:any*/);
+	var range/*:Range*/ = ({ s: { c: 0, r: 0 }, e: { c: 0, r: js.length } }/*:any*/);
 	var hdr = o.header || [], C = 0;
 
 	js.forEach(function (JS, R) {
-		keys(JS).filter(function(x) { return JS.hasOwnProperty(x); }).forEach(function(k) {
-			if((C=hdr.indexOf(k)) == -1) hdr[C=hdr.length] = k;
+		keys(JS).filter(function (x) { return JS.hasOwnProperty(x); }).forEach(function (k) {
+			if ((C = hdr.indexOf(k)) == -1) hdr[C = hdr.length] = k;
 			var v = JS[k];
 			var t = 'z';
 			var z = "";
-			if(typeof v == 'number') t = 'n';
-			else if(typeof v == 'boolean') t = 'b';
-			else if(typeof v == 'string') t = 's';
-			else if(v instanceof Date) {
+			if (typeof v == 'number') t = 'n';
+			else if (typeof v == 'boolean') t = 'b';
+			else if (typeof v == 'string') t = 's';
+			else if (v instanceof Date) {
 				t = 'd';
-				if(!o.cellDates) { t = 'n'; v = datenum(v); }
+				if (!o.cellDates) { t = 'n'; v = datenum(v); }
 				z = o.dateNF || SSF._table[14];
 			}
-			ws[encode_cell({c:C,r:R+1})] = cell = ({t:t, v:v}/*:any*/);
-			if(z) cell.z = z;
+			ws[encode_cell({ c: C, r: R + 1 })] = cell = ({ t: t, v: v }/*:any*/);
+			if (z) cell.z = z;
 		});
 	});
 	range.e.c = hdr.length - 1;
-	for(C = 0; C < hdr.length; ++C) ws[encode_col(C) + "1"] = {t:'s', v:hdr[C]};
+	for (C = 0; C < hdr.length; ++C) ws[encode_col(C) + "1"] = { t: 's', v: hdr[C] };
 	ws['!ref'] = encode_range(range);
 	return ws;
 }

--- a/xlsx.js
+++ b/xlsx.js
@@ -18536,41 +18536,41 @@ function writeFileAsync(filename, wb, opts, cb) {
 	return _fs.writeFile(filename, writeSync(wb, o), _cb);
 }
 function sheet_to_json(sheet, opts) {
-	if(sheet == null || sheet["!ref"] == null) return [];
-	var val = {t:'n',v:0}, header = 0, offset = 1, hdr = [], isempty = true, v=0, vv="";
-	var r = {s:{r:0,c:0},e:{r:0,c:0}};
+	if (sheet == null || sheet["!ref"] == null) return [];
+	var val = { t: 'n', v: 0 }, header = 0, offset = 1, hdr = [], isempty = true, v = 0, vv = "";
+	var r = { s: { r: 0, c: 0 }, e: { r: 0, c: 0 } };
 	var o = opts || {};
 	var raw = o.raw;
 	var defval = o.defval;
 	var range = o.range != null ? o.range : sheet["!ref"];
-	if(o.header === 1) header = 1;
-	else if(o.header === "A") header = 2;
-	else if(Array.isArray(o.header)) header = 3;
-	switch(typeof range) {
+	if (o.header === 1) header = 1;
+	else if (o.header === "A") header = 2;
+	else if (Array.isArray(o.header)) header = 3;
+	switch (typeof range) {
 		case 'string': r = safe_decode_range(range); break;
 		case 'number': r = safe_decode_range(sheet["!ref"]); r.s.r = range; break;
 		default: r = range;
 	}
-	if(header > 0) offset = 0;
+	if (header > 0) offset = 0;
 	var rr = encode_row(r.s.r);
 	var cols = [];
 	var out = [];
 	var outi = 0, counter = 0;
 	var dense = Array.isArray(sheet);
 	var R = r.s.r, C = 0, CC = 0;
-	if(dense && !sheet[R]) sheet[R] = [];
-	for(C = r.s.c; C <= r.e.c; ++C) {
+	if (dense && !sheet[R]) sheet[R] = [];
+	for (C = r.s.c; C <= r.e.c; ++C) {
 		cols[C] = encode_col(C);
 		val = dense ? sheet[R][C] : sheet[cols[C] + rr];
-		switch(header) {
+		switch (header) {
 			case 1: hdr[C] = C - r.s.c; break;
 			case 2: hdr[C] = cols[C]; break;
 			case 3: hdr[C] = o.header[C - r.s.c]; break;
 			default:
-				if(val == null) continue;
+				if (val == null) continue;
 				vv = v = format_cell(val, null, o);
 				counter = 0;
-				for(CC = 0; CC < hdr.length; ++CC) if(hdr[CC] == vv) vv = v + "_" + (++counter);
+				for (CC = 0; CC < hdr.length; ++CC) if (hdr[CC] == vv) vv = v + "_" + (++counter);
 				hdr[C] = vv;
 		}
 	}
@@ -18578,38 +18578,38 @@ function sheet_to_json(sheet, opts) {
 	for (R = r.s.r + offset; R <= r.e.r; ++R) {
 		rr = encode_row(R);
 		isempty = true;
-		if(header === 1) row = [];
+		if (header === 1) row = [];
 		else {
 			row = {};
-			if(Object.defineProperty) try { Object.defineProperty(row, '__rowNum__', {value:R, enumerable:false}); } catch(e) { row.__rowNum__ = R; }
+			if (Object.defineProperty) try { Object.defineProperty(row, '__rowNum__', { value: R, enumerable: false }); } catch (e) { row.__rowNum__ = R; }
 			else row.__rowNum__ = R;
 		}
-		if(!dense || sheet[R]) for (C = r.s.c; C <= r.e.c; ++C) {
+		if (!dense || sheet[R]) for (C = r.s.c; C <= r.e.c; ++C) {
 			val = dense ? sheet[R][C] : sheet[cols[C] + rr];
-			if(val === undefined || val.t === undefined) {
-				if(defval === undefined) continue;
-				if(hdr[C] != null) { row[hdr[C]] = defval; isempty = false; }
+			if (val === undefined || val.t === undefined) {
+				if (defval === undefined) continue;
+				if (hdr[C] != null) { row[hdr[C]] = defval; isempty = false; }
 				continue;
 			}
 			v = val.v;
-			switch(val.t){
-				case 'z': if(v == null) break; continue;
+			switch (val.t) {
+				case 'z': if (v == null) break; continue;
 				case 'e': continue;
 				case 's': case 'd': case 'b': case 'n': break;
 				default: throw new Error('unrecognized type ' + val.t);
 			}
-			if(hdr[C] != null) {
-				if(v == null) {
-					if(defval !== undefined) row[hdr[C]] = defval;
-					else if(raw && v === null) row[hdr[C]] = null;
+			if (hdr[C] != null) {
+				if (v == null) {
+					if (defval !== undefined) row[hdr[C]] = defval;
+					else if (raw && v === null) row[hdr[C]] = null;
 					else continue;
 				} else {
-					row[hdr[C]] = raw ? v : format_cell(val,v,o);
+					row[hdr[C]] = raw ? v : format_cell(val, v, o);
 				}
 				isempty = false;
 			}
 		}
-		if((isempty === false) || (header === 1 ? o.blankrows !== false : !!o.blankrows)) out[outi++] = row;
+		if ((isempty === false) || (header === 1 ? o.blankrows !== false : !!o.blankrows)) out[outi++] = row;
 	}
 	out.length = outi;
 	return out;
@@ -18619,44 +18619,48 @@ var qreg = /"/g;
 function make_csv_row(sheet, r, R, cols, fs, rs, FS, o) {
 	var isempty = true;
 	var row = [], txt = "", rr = encode_row(R);
-	for(var C = r.s.c; C <= r.e.c; ++C) {
+	for (var C = r.s.c; C <= r.e.c; ++C) {
 		if (!cols[C]) continue;
-		var val = o.dense ? (sheet[R]||[])[C]: sheet[cols[C] + rr];
-		if(val == null) txt = "";
-		else if(val.v != null) {
+		var val = o.dense ? (sheet[R] || [])[C] : sheet[cols[C] + rr];
+		if (val == null) txt = "";
+		else if (val.v != null) {
 			isempty = false;
-			txt = ''+format_cell(val, null, o);
-			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
-			if(txt == "ID") txt = '"ID"';
-		} else if(val.f != null && !val.F) {
+			txt = '' + format_cell(val, null, o);
+			for (var i = 0, cc = 0; i !== txt.length; ++i) if ((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34) { txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
+			if (o.clean) {
+				txt = txt.replace(/\s\s+/g, ' ');
+				txt = txt.trim();
+			}
+			if (txt == "ID") txt = '"ID"';
+		} else if (val.f != null && !val.F) {
 			isempty = false;
-			txt = '=' + val.f; if(txt.indexOf(",") >= 0) txt = '"' + txt.replace(qreg, '""') + '"';
+			txt = '=' + val.f; if (txt.indexOf(",") >= 0) txt = '"' + txt.replace(qreg, '""') + '"';
 		} else txt = "";
 		/* NOTE: Excel CSV does not support array formulae */
 		row.push(txt);
 	}
-	if(o.blankrows === false && isempty) return null;
+	if (o.blankrows === false && isempty) return null;
 	return row.join(FS);
 }
 
 function sheet_to_csv(sheet, opts) {
 	var out = [];
 	var o = opts == null ? {} : opts;
-	if(sheet == null || sheet["!ref"] == null) return "";
+	if (sheet == null || sheet["!ref"] == null) return "";
 	var r = safe_decode_range(sheet["!ref"]);
 	var FS = o.FS !== undefined ? o.FS : ",", fs = FS.charCodeAt(0);
 	var RS = o.RS !== undefined ? o.RS : "\n", rs = RS.charCodeAt(0);
-	var endregex = new RegExp((FS=="|" ? "\\|" : FS)+"+$");
+	var endregex = new RegExp((FS == "|" ? "\\|" : FS) + "+$");
 	var row = "", cols = [];
 	o.dense = Array.isArray(sheet);
 	var colInfos = o.skipHidden && sheet["!cols"] || [];
 	var rowInfos = o.skipHidden && sheet["!rows"] || [];
-	for(var C = r.s.c; C <= r.e.c; ++C) if (!((colInfos[C]||{}).hidden)) cols[C] = encode_col(C);
-	for(var R = r.s.r; R <= r.e.r; ++R) {
-		if ((rowInfos[R]||{}).hidden) continue;
+	for (var C = r.s.c; C <= r.e.c; ++C) if (!((colInfos[C] || {}).hidden)) cols[C] = encode_col(C);
+	for (var R = r.s.r; R <= r.e.r; ++R) {
+		if ((rowInfos[R] || {}).hidden) continue;
 		row = make_csv_row(sheet, r, R, cols, fs, rs, FS, o);
-		if(row == null) { continue; }
-		if(o.strip) row = row.replace(endregex,"");
+		if (row == null) { continue; }
+		if (o.strip) row = row.replace(endregex, "");
 		out.push(row + RS);
 	}
 	delete o.dense;
@@ -18664,41 +18668,41 @@ function sheet_to_csv(sheet, opts) {
 }
 
 function sheet_to_txt(sheet, opts) {
-	if(!opts) opts = {}; opts.FS = "\t"; opts.RS = "\n";
+	if (!opts) opts = {}; opts.FS = "\t"; opts.RS = "\n";
 	var s = sheet_to_csv(sheet, opts);
-	if(typeof cptable == 'undefined' || opts.type == 'string') return s;
+	if (typeof cptable == 'undefined' || opts.type == 'string') return s;
 	var o = cptable.utils.encode(1200, s, 'str');
 	return "\xff\xfe" + o;
 }
 
 function sheet_to_formulae(sheet) {
-	var y = "", x, val="";
-	if(sheet == null || sheet["!ref"] == null) return [];
+	var y = "", x, val = "";
+	if (sheet == null || sheet["!ref"] == null) return [];
 	var r = safe_decode_range(sheet['!ref']), rr = "", cols = [], C;
 	var cmds = [];
 	var dense = Array.isArray(sheet);
-	for(C = r.s.c; C <= r.e.c; ++C) cols[C] = encode_col(C);
-	for(var R = r.s.r; R <= r.e.r; ++R) {
+	for (C = r.s.c; C <= r.e.c; ++C) cols[C] = encode_col(C);
+	for (var R = r.s.r; R <= r.e.r; ++R) {
 		rr = encode_row(R);
-		for(C = r.s.c; C <= r.e.c; ++C) {
+		for (C = r.s.c; C <= r.e.c; ++C) {
 			y = cols[C] + rr;
-			x = dense ? (sheet[R]||[])[C] : sheet[y];
+			x = dense ? (sheet[R] || [])[C] : sheet[y];
 			val = "";
-			if(x === undefined) continue;
-			else if(x.F != null) {
+			if (x === undefined) continue;
+			else if (x.F != null) {
 				y = x.F;
-				if(!x.f) continue;
+				if (!x.f) continue;
 				val = x.f;
-				if(y.indexOf(":") == -1) y = y + ":" + y;
+				if (y.indexOf(":") == -1) y = y + ":" + y;
 			}
-			if(x.f != null) val = x.f;
-			else if(x.t == 'z') continue;
-			else if(x.t == 'n' && x.v != null) val = "" + x.v;
-			else if(x.t == 'b') val = x.v ? "TRUE" : "FALSE";
-			else if(x.w !== undefined) val = "'" + x.w;
-			else if(x.v === undefined) continue;
-			else if(x.t == 's') val = "'" + x.v;
-			else val = ""+x.v;
+			if (x.f != null) val = x.f;
+			else if (x.t == 'z') continue;
+			else if (x.t == 'n' && x.v != null) val = "" + x.v;
+			else if (x.t == 'b') val = x.v ? "TRUE" : "FALSE";
+			else if (x.w !== undefined) val = "'" + x.w;
+			else if (x.v === undefined) continue;
+			else if (x.t == 's') val = "'" + x.v;
+			else val = "" + x.v;
 			cmds[cmds.length] = y + "=" + val;
 		}
 	}
@@ -18709,29 +18713,29 @@ function json_to_sheet(js, opts) {
 	var o = opts || {};
 	var ws = ({});
 	var cell;
-	var range = ({s: {c:0, r:0}, e: {c:0, r:js.length}});
+	var range = ({ s: { c: 0, r: 0 }, e: { c: 0, r: js.length } });
 	var hdr = o.header || [], C = 0;
 
 	js.forEach(function (JS, R) {
-		keys(JS).filter(function(x) { return JS.hasOwnProperty(x); }).forEach(function(k) {
-			if((C=hdr.indexOf(k)) == -1) hdr[C=hdr.length] = k;
+		keys(JS).filter(function (x) { return JS.hasOwnProperty(x); }).forEach(function (k) {
+			if ((C = hdr.indexOf(k)) == -1) hdr[C = hdr.length] = k;
 			var v = JS[k];
 			var t = 'z';
 			var z = "";
-			if(typeof v == 'number') t = 'n';
-			else if(typeof v == 'boolean') t = 'b';
-			else if(typeof v == 'string') t = 's';
-			else if(v instanceof Date) {
+			if (typeof v == 'number') t = 'n';
+			else if (typeof v == 'boolean') t = 'b';
+			else if (typeof v == 'string') t = 's';
+			else if (v instanceof Date) {
 				t = 'd';
-				if(!o.cellDates) { t = 'n'; v = datenum(v); }
+				if (!o.cellDates) { t = 'n'; v = datenum(v); }
 				z = o.dateNF || SSF._table[14];
 			}
-			ws[encode_cell({c:C,r:R+1})] = cell = ({t:t, v:v});
-			if(z) cell.z = z;
+			ws[encode_cell({ c: C, r: R + 1 })] = cell = ({ t: t, v: v });
+			if (z) cell.z = z;
 		});
 	});
 	range.e.c = hdr.length - 1;
-	for(C = 0; C < hdr.length; ++C) ws[encode_col(C) + "1"] = {t:'s', v:hdr[C]};
+	for (C = 0; C < hdr.length; ++C) ws[encode_col(C) + "1"] = { t: 's', v: hdr[C] };
 	ws['!ref'] = encode_range(range);
 	return ws;
 }


### PR DESCRIPTION
Added an option `--clean` to make CSV export to remove new lines from cell content, and trim the content also