### PR TITLE
added start script to electron demo

### DIFF
--- a/demos/electron/package.json
+++ b/demos/electron/package.json
@@ -3,6 +3,9 @@
 	"author": "sheetjs",
 	"version": "0.0.0",
 	"main": "main.js",
+        "scripts": {
+            "start": "electron ."
+         },
 	"dependencies": {
 		"electron": "~1.7.x",
 		"xlsx": "*"


### PR DESCRIPTION
when I run the application without this line 
 "scripts": {
    "start": "electron ."
  }, 
it doesn't work and it gives me an error saying that the start script is missing.