### PR TITLE
fix: zero number format bug

### DIFF
--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -278,7 +278,7 @@ function write_ws_xml_cell(cell/*:Cell*/, ref, ws, opts/*::, idx, wb*/)/*:string
 			o.t = "str"; break;
 	}
 	if(cell.t != oldt) { cell.t = oldt; cell.v = oldv; }
-	if(cell.f) {
+	if(cell.f !== undefined) {
 		var ff = cell.F && cell.F.slice(0, ref.length) == ref ? {t:"array", ref:cell.F} : null;
 		v = writextag('f', escapexml(cell.f), ff) + (cell.v != null ? v : "");
 	}

--- a/dist/xlsx.extendscript.js
+++ b/dist/xlsx.extendscript.js
@@ -22421,7 +22421,7 @@ function write_ws_xml_cell(cell, ref, ws, opts) {
 			o.t = "str"; break;
 	}
 	if(cell.t != oldt) { cell.t = oldt; cell.v = oldv; }
-	if(cell.f) {
+	if(cell.f !== undefined) {
 		var ff = cell.F && cell.F.slice(0, ref.length) == ref ? {t:"array", ref:cell.F} : null;
 		v = writextag('f', escapexml(cell.f), ff) + (cell.v != null ? v : "");
 	}

--- a/dist/xlsx.js
+++ b/dist/xlsx.js
@@ -13265,7 +13265,7 @@ function write_ws_xml_cell(cell, ref, ws, opts) {
 			o.t = "str"; break;
 	}
 	if(cell.t != oldt) { cell.t = oldt; cell.v = oldv; }
-	if(cell.f) {
+	if(cell.f !== undefined) {
 		var ff = cell.F && cell.F.slice(0, ref.length) == ref ? {t:"array", ref:cell.F} : null;
 		v = writextag('f', escapexml(cell.f), ff) + (cell.v != null ? v : "");
 	}

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -13367,7 +13367,7 @@ function write_ws_xml_cell(cell/*:Cell*/, ref, ws, opts/*::, idx, wb*/)/*:string
 			o.t = "str"; break;
 	}
 	if(cell.t != oldt) { cell.t = oldt; cell.v = oldv; }
-	if(cell.f) {
+	if(cell.f !== undefined) {
 		var ff = cell.F && cell.F.slice(0, ref.length) == ref ? {t:"array", ref:cell.F} : null;
 		v = writextag('f', escapexml(cell.f), ff) + (cell.v != null ? v : "");
 	}

--- a/xlsx.js
+++ b/xlsx.js
@@ -13265,7 +13265,7 @@ function write_ws_xml_cell(cell, ref, ws, opts) {
 			o.t = "str"; break;
 	}
 	if(cell.t != oldt) { cell.t = oldt; cell.v = oldv; }
-	if(cell.f) {
+	if(cell.f !== undefined) {
 		var ff = cell.F && cell.F.slice(0, ref.length) == ref ? {t:"array", ref:cell.F} : null;
 		v = writextag('f', escapexml(cell.f), ff) + (cell.v != null ? v : "");
 	}

--- a/xlsx.mini.flow.js
+++ b/xlsx.mini.flow.js
@@ -6399,7 +6399,7 @@ function write_ws_xml_cell(cell/*:Cell*/, ref, ws, opts/*::, idx, wb*/)/*:string
 			o.t = "str"; break;
 	}
 	if(cell.t != oldt) { cell.t = oldt; cell.v = oldv; }
-	if(cell.f) {
+	if(cell.f !== undefined) {
 		var ff = cell.F && cell.F.slice(0, ref.length) == ref ? {t:"array", ref:cell.F} : null;
 		v = writextag('f', escapexml(cell.f), ff) + (cell.v != null ? v : "");
 	}

--- a/xlsx.mini.js
+++ b/xlsx.mini.js
@@ -6309,7 +6309,7 @@ function write_ws_xml_cell(cell, ref, ws, opts) {
 			o.t = "str"; break;
 	}
 	if(cell.t != oldt) { cell.t = oldt; cell.v = oldv; }
-	if(cell.f) {
+	if(cell.f !== undefined) {
 		var ff = cell.F && cell.F.slice(0, ref.length) == ref ? {t:"array", ref:cell.F} : null;
 		v = writextag('f', escapexml(cell.f), ff) + (cell.v != null ? v : "");
 	}


### PR DESCRIPTION
## test demo in nodejs
```
var xlsx = require('node-xlsx');
var fs = require('fs');

const data = [[1, {t: 'n', f: 2, z: 2}, {t: 'n', f: 0, z: 2}]]

var buffer = xlsx.build([{name: "mySheetName", data: data}]); // Returns a buffer
fs.writeFileSync('test.xlsx', buffer)
```
## before change
![2019-12-12 17-52-03屏幕截图](https://user-images.githubusercontent.com/5196122/70701990-44d56100-1d08-11ea-843c-781ffe5fd85c.png)
## after change
![2019-12-12 17-53-03屏幕截图](https://user-images.githubusercontent.com/5196122/70701989-443cca80-1d08-11ea-9313-6eb7cda75492.png)
