### PR TITLE
fix: #1717

### DIFF
--- a/bits/81_writeods.js
+++ b/bits/81_writeods.js
@@ -78,7 +78,7 @@ var write_content_ods/*:{(wb:any, opts:any):string}*/ = (function() {
 						ct['office:value'] = (cell.v||0);
 						break;
 					case 's': case 'str':
-						textp = cell.v;
+						textp = cell.v || "";
 						ct['office:value-type'] = "string";
 						break;
 					case 'd':


### PR DESCRIPTION
I saw the issue was raised and a SheetJS Dev said the fix was simple and involved dealing with defined and undefined variables.
They wrote a line using a ternary conditional to assign the variable textp to the value of cell.v if it's defined, or an empty string if it is not defined. 

SheetJS Dev Code: textp = cell.v == null ? "" : cell.v;

Suggesting using the line: textp = cell.v || "";

This does the same thing and assigns textp to cell.v if it is defined or an empty string if it is not. 

(Note any feedback would be greatly appreciated, this is my first try at contributing to open source).