### PR TITLE
fix: #1883 Add TypeScript

### DIFF
--- a/bits/04_base64.js
+++ b/bits/04_base64.js
@@ -1,44 +1,49 @@
-var Base64 = (function make_b64(){
-	var map = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-	return {
-		encode: function(input/*:string*/)/*:string*/ {
-			var o = "";
-			var c1=0, c2=0, c3=0, e1=0, e2=0, e3=0, e4=0;
-			for(var i = 0; i < input.length; ) {
-				c1 = input.charCodeAt(i++);
-				e1 = (c1 >> 2);
-
-				c2 = input.charCodeAt(i++);
-				e2 = ((c1 & 3) << 4) | (c2 >> 4);
-
-				c3 = input.charCodeAt(i++);
-				e3 = ((c2 & 15) << 2) | (c3 >> 6);
-				e4 = (c3 & 63);
-				if (isNaN(c2)) { e3 = e4 = 64; }
-				else if (isNaN(c3)) { e4 = 64; }
-				o += map.charAt(e1) + map.charAt(e2) + map.charAt(e3) + map.charAt(e4);
-			}
-			return o;
-		},
-		decode: function b64_decode(input/*:string*/)/*:string*/ {
-			var o = "";
-			var c1=0, c2=0, c3=0, e1=0, e2=0, e3=0, e4=0;
-			input = input.replace(/[^\w\+\/\=]/g, "");
-			for(var i = 0; i < input.length;) {
-				e1 = map.indexOf(input.charAt(i++));
-				e2 = map.indexOf(input.charAt(i++));
-				c1 = (e1 << 2) | (e2 >> 4);
-				o += String.fromCharCode(c1);
-
-				e3 = map.indexOf(input.charAt(i++));
-				c2 = ((e2 & 15) << 4) | (e3 >> 2);
-				if (e3 !== 64) { o += String.fromCharCode(c2); }
-
-				e4 = map.indexOf(input.charAt(i++));
-				c3 = ((e3 & 3) << 6) | e4;
-				if (e4 !== 64) { o += String.fromCharCode(c3); }
-			}
-			return o;
-		}
-	};
+"use strict";
+var Base64 = (function make_b64() {
+    var map = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+    return {
+        encode: function (input) {
+            var o = '';
+            var c1 = 0, c2 = 0, c3 = 0, e1 = 0, e2 = 0, e3 = 0, e4 = 0;
+            for (var i = 0; i < input.length;) {
+                c1 = input.charCodeAt(i++);
+                e1 = c1 >> 2;
+                c2 = input.charCodeAt(i++);
+                e2 = ((c1 & 3) << 4) | (c2 >> 4);
+                c3 = input.charCodeAt(i++);
+                e3 = ((c2 & 15) << 2) | (c3 >> 6);
+                e4 = c3 & 63;
+                if (isNaN(c2)) {
+                    e3 = e4 = 64;
+                }
+                else if (isNaN(c3)) {
+                    e4 = 64;
+                }
+                o += map.charAt(e1) + map.charAt(e2) + map.charAt(e3) + map.charAt(e4);
+            }
+            return o;
+        },
+        decode: function b64_decode(input) {
+            var o = '';
+            var c1 = 0, c2 = 0, c3 = 0, e1 = 0, e2 = 0, e3 = 0, e4 = 0;
+            input = input.replace(/[^\w\+\/\=]/g, '');
+            for (var i = 0; i < input.length;) {
+                e1 = map.indexOf(input.charAt(i++));
+                e2 = map.indexOf(input.charAt(i++));
+                c1 = (e1 << 2) | (e2 >> 4);
+                o += String.fromCharCode(c1);
+                e3 = map.indexOf(input.charAt(i++));
+                c2 = ((e2 & 15) << 4) | (e3 >> 2);
+                if (e3 !== 64) {
+                    o += String.fromCharCode(c2);
+                }
+                e4 = map.indexOf(input.charAt(i++));
+                c3 = ((e3 & 3) << 6) | e4;
+                if (e4 !== 64) {
+                    o += String.fromCharCode(c3);
+                }
+            }
+            return o;
+        },
+    };
 })();

--- a/bits/04_base64.ts
+++ b/bits/04_base64.ts
@@ -1,0 +1,63 @@
+var Base64 = (function make_b64() {
+  var map = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+  return {
+    encode: function (input: string): string {
+      var o = '';
+      var c1 = 0,
+        c2 = 0,
+        c3 = 0,
+        e1 = 0,
+        e2 = 0,
+        e3 = 0,
+        e4 = 0;
+      for (var i = 0; i < input.length; ) {
+        c1 = input.charCodeAt(i++);
+        e1 = c1 >> 2;
+
+        c2 = input.charCodeAt(i++);
+        e2 = ((c1 & 3) << 4) | (c2 >> 4);
+
+        c3 = input.charCodeAt(i++);
+        e3 = ((c2 & 15) << 2) | (c3 >> 6);
+        e4 = c3 & 63;
+        if (isNaN(c2)) {
+          e3 = e4 = 64;
+        } else if (isNaN(c3)) {
+          e4 = 64;
+        }
+        o += map.charAt(e1) + map.charAt(e2) + map.charAt(e3) + map.charAt(e4);
+      }
+      return o;
+    },
+    decode: function b64_decode(input: string): string {
+      var o = '';
+      var c1 = 0,
+        c2 = 0,
+        c3 = 0,
+        e1 = 0,
+        e2 = 0,
+        e3 = 0,
+        e4 = 0;
+      input = input.replace(/[^\w\+\/\=]/g, '');
+      for (var i = 0; i < input.length; ) {
+        e1 = map.indexOf(input.charAt(i++));
+        e2 = map.indexOf(input.charAt(i++));
+        c1 = (e1 << 2) | (e2 >> 4);
+        o += String.fromCharCode(c1);
+
+        e3 = map.indexOf(input.charAt(i++));
+        c2 = ((e2 & 15) << 4) | (e3 >> 2);
+        if (e3 !== 64) {
+          o += String.fromCharCode(c2);
+        }
+
+        e4 = map.indexOf(input.charAt(i++));
+        c3 = ((e3 & 3) << 6) | e4;
+        if (e4 !== 64) {
+          o += String.fromCharCode(c3);
+        }
+      }
+      return o;
+    },
+  };
+})();

--- a/package.json
+++ b/package.json
@@ -1,87 +1,88 @@
 {
-	"name": "xlsx",
-	"version": "0.15.6",
-	"author": "sheetjs",
-	"description": "SheetJS Spreadsheet data parser and writer",
-	"keywords": [
-		"excel",
-		"xls",
-		"xlsx",
-		"xlsb",
-		"xlsm",
-		"ods",
-		"csv",
-		"dbf",
-		"dif",
-		"sylk",
-		"office",
-		"spreadsheet"
-	],
-	"bin": {
-		"xlsx": "./bin/xlsx.njs"
-	},
-	"main": "./xlsx",
-	"unpkg": "dist/xlsx.min.js",
-	"jsdelivr": "dist/xlsx.min.js",
-	"types": "types",
-	"browser": {
-		"buffer": false,
-		"crypto": false,
-		"stream": false,
-		"process": false,
-		"fs": false
-	},
-	"dependencies": {
-		"adler-32": "~1.2.0",
-		"cfb": "^1.1.4",
-		"codepage": "~1.14.0",
-		"commander": "~2.17.1",
-		"crc-32": "~1.2.0",
-		"exit-on-epipe": "~1.0.1",
-		"wmf": "~1.0.1",
-		"ssf": "~0.10.3"
-	},
-	"devDependencies": {
-		"@sheetjs/uglify-js": "~2.7.3",
-		"@types/node": "^8.5.9",
-		"blanket": "~1.2.3",
-		"dtslint": "^0.1.2",
-		"jsdom": "~11.1.0",
-		"mocha": "~2.5.3",
-		"typescript": "2.2.0"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/SheetJS/js-xlsx.git"
-	},
-	"scripts": {
-		"pretest": "git submodule init && git submodule update",
-		"test": "make travis",
-		"build": "make",
-		"lint": "make fullint",
-		"dtslint": "dtslint types"
-	},
-	"config": {
-		"blanket": {
-			"pattern": "xlsx.js"
-		}
-	},
-	"alex": {
-		"allow": [
-			"special",
-			"simple",
-			"just",
-			"crash",
-			"wtf",
-			"holes"
-		]
-	},
-	"homepage": "https://sheetjs.com/",
-	"bugs": {
-		"url": "https://github.com/SheetJS/js-xlsx/issues"
-	},
-	"license": "Apache-2.0",
-	"engines": {
-		"node": ">=0.8"
-	}
+  "name": "xlsx",
+  "version": "0.15.6",
+  "author": "sheetjs",
+  "description": "SheetJS Spreadsheet data parser and writer",
+  "keywords": [
+    "excel",
+    "xls",
+    "xlsx",
+    "xlsb",
+    "xlsm",
+    "ods",
+    "csv",
+    "dbf",
+    "dif",
+    "sylk",
+    "office",
+    "spreadsheet"
+  ],
+  "bin": {
+    "xlsx": "./bin/xlsx.njs"
+  },
+  "main": "./xlsx",
+  "unpkg": "dist/xlsx.min.js",
+  "jsdelivr": "dist/xlsx.min.js",
+  "types": "types",
+  "browser": {
+    "buffer": false,
+    "crypto": false,
+    "stream": false,
+    "process": false,
+    "fs": false
+  },
+  "dependencies": {
+    "adler-32": "~1.2.0",
+    "cfb": "^1.1.4",
+    "codepage": "~1.14.0",
+    "commander": "~2.17.1",
+    "crc-32": "~1.2.0",
+    "exit-on-epipe": "~1.0.1",
+    "wmf": "~1.0.1",
+    "ssf": "~0.10.3"
+  },
+  "devDependencies": {
+    "@sheetjs/uglify-js": "~2.7.3",
+    "@types/node": "^8.5.9",
+    "blanket": "~1.2.3",
+    "dtslint": "^0.1.2",
+    "jsdom": "~11.1.0",
+    "mocha": "~2.5.3",
+    "typescript": "^3.8.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/SheetJS/js-xlsx.git"
+  },
+  "scripts": {
+    "tsbuild": "tsc",
+    "pretest": "git submodule init && git submodule update",
+    "test": "make travis",
+    "build": "make",
+    "lint": "make fullint",
+    "dtslint": "dtslint types"
+  },
+  "config": {
+    "blanket": {
+      "pattern": "xlsx.js"
+    }
+  },
+  "alex": {
+    "allow": [
+      "special",
+      "simple",
+      "just",
+      "crash",
+      "wtf",
+      "holes"
+    ]
+  },
+  "homepage": "https://sheetjs.com/",
+  "bugs": {
+    "url": "https://github.com/SheetJS/js-xlsx/issues"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=0.8"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,67 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+  },
+  "include": ["bits"]
+}


### PR DESCRIPTION
Tasks:

- create a TypeScript first configuration
- create `tsbuild` npm script
- create the file `bits/04_base64.ts`

With this PR, I proposed to create the file `bits/04_base64.ts` and the corresponding `.js` is generated running the command `npm run tsbuild`, which will create `bits/04_base64.js` file.

I've kept the original `tsconfig.json` file to be easier to adjust if we want to. When the final configuration arrives, we delete all commented properties.