### PR TITLE
fix undefined range for writeFile - test with ods

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -3563,7 +3563,7 @@ function unfix_col(cstr) { return cstr.replace(/^\$([A-Z])/,"$1"); }
 function split_cell(cstr) { return cstr.replace(/(\$?[A-Z]*)(\$?\d*)/,"$1,$2").split(","); }
 function decode_cell(cstr) { var splt = split_cell(cstr); return { c:decode_col(splt[0]), r:decode_row(splt[1]) }; }
 function encode_cell(cell) { return encode_col(cell.c) + encode_row(cell.r); }
-function decode_range(range) { var x =range.split(":").map(decode_cell); return {s:x[0],e:x[x.length-1]}; }
+function decode_range(range) { var x =(range||"A1A1").split(":").map(decode_cell); return {s:x[0],e:x[x.length-1]}; }
 function encode_range(cs,ce) {
 	if(typeof ce === 'undefined' || typeof ce === 'number') {
 return encode_range(cs.s, cs.e);


### PR DESCRIPTION
fix undefined range for writeFile - test with ods as said in #1914

This FIX

    function decode_range(range) { var x = (range||"A1A1").split(":").map(decode_cell); return {s:x[0],e:x[x.length-1]}; }

You are right correction doesn't fit LibreOffice behaviour. So I will propose another Fix :-)

LibreOffice Sheet with empty table : content.xml extract
```

<table:table table:name="test1_libreOffice" table:style-name="ta1">
    <table:table-column table:style-name="co1" table:default-cell-style-name="Default"/>
<table:table-row table:style-name="ro2">
<table:table-cell/>
</table:table-row>
</table:table>
```

LibreOffice Sheet with one element in table : content.xml extract
```

<table:table table:name="test2_libreOffice" table:style-name="ta1">
   <table:table-column table:style-name="co1" table:default-cell-style-name="ce1"/>
       <table:table-row table:style-name="ro1">
       <table:table-cell office:value-type="string" calcext:value-type="string">
           <text:p>merde</text:p>
       </table:table-cell>
    </table:table-row>
</table:table>
```

SheetJS writed file with my correction for an empty sheet :

```
    <table:table table:name="test1_sheetJS_ods">
        <table:table-row>
          <table:table-cell />
        </table:table-row>
      </table:table>
```

SheetJS writed file with my correction for an one cell sheet +1

```
<table:table table:name="test2_sheetJS_ods">
     <table:table-row>
          <table:table-cell />
         <table:table-cell office:value-type="string"><text:p>TOIP</text:p></table:table-cell>
          <table:covered-table-cell/>
          <table:table-cell />
    </table:table-row>
</table:table>
```


Do you agree to accept a New Pull Request ?