### PR TITLE
Add missing v0.16.1 data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This log is intended to keep track of backwards-incompatible changes, including
 but not limited to API changes and file location changes.  Minor behavioral
 changes may not be included if they are not expected to break existing code.
 
+## v0.16.1
+* Custom Properties use correct encoding https://github.com/SheetJS/sheetjs/pull/1910 and https://github.com/SheetJS/sheetjs/issues/1909
+* AMD wrapper change (see https://github.com/SheetJS/sheetjs/issues/1937)
+
 ## v0.16.0
 * Date handling changed
 * XLML certain tag tests are now case insensitive


### PR DESCRIPTION
v0.16.1 has been released but there is no info in the changelog, this PR adds missing info about new release to the changelog