### PR TITLE
fix: disabling PRN by default

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -7626,6 +7626,7 @@ var PRN = (function() {
 	}
 
 	function prn_to_sheet_str(str, opts) {
+		if(!(opts && opts.PRN)) return dsv_to_sheet_str(str, opts);
 		if(str.slice(0,4) == "sep=") return dsv_to_sheet_str(str, opts);
 		if(str.indexOf("\t") >= 0 || str.indexOf(",") >= 0 || str.indexOf(";") >= 0) return dsv_to_sheet_str(str, opts);
 		return aoa_to_sheet(prn_to_aoa_str(str, opts), opts);


### PR DESCRIPTION
Fix: Parsing CSVs with one column [#1976 ](https://github.com/SheetJS/sheetjs/issues/1976), by disabling PRN parsing by default.