### PR TITLE
Update the Electron Demo

### DIFF
--- a/demos/electron/main.js
+++ b/demos/electron/main.js
@@ -10,7 +10,6 @@ function createWindow() {
 	if (win) return;
 	win = new electron.BrowserWindow({
 		width: 800, height: 600,
-		//The lines below solved the issue
 		webPreferences: {
 			nodeIntegration: true
 		}

--- a/demos/electron/main.js
+++ b/demos/electron/main.js
@@ -7,14 +7,20 @@ var app = electron.app;
 var win = null;
 
 function createWindow() {
-	if(win) return;
-	win = new electron.BrowserWindow({width:800, height:600});
+	if (win) return;
+	win = new electron.BrowserWindow({
+		width: 800, height: 600,
+		//The lines below solved the issue
+		webPreferences: {
+			nodeIntegration: true
+		}
+	});
 	win.loadURL("file://" + __dirname + "/index.html");
 	win.webContents.openDevTools();
-	win.on('closed', function() { win = null; });
+	win.on('closed', function () { win = null; });
 }
-if(app.setAboutPanelOptions) app.setAboutPanelOptions({ applicationName: 'sheetjs-electron', applicationVersion: "XLSX " + XLSX.version, copyright: "(C) 2017-present SheetJS LLC" });
-app.on('open-file', function() { console.log(arguments); });
+if (app.setAboutPanelOptions) app.setAboutPanelOptions({ applicationName: 'sheetjs-electron', applicationVersion: "XLSX " + XLSX.version, copyright: "(C) 2017-present SheetJS LLC" });
+app.on('open-file', function () { console.log(arguments); });
 app.on('ready', createWindow);
 app.on('activate', createWindow);
-app.on('window-all-closed', function() { if(process.platform !== 'darwin') app.quit(); });
+app.on('window-all-closed', function () { if (process.platform !== 'darwin') app.quit(); });

--- a/demos/electron/package.json
+++ b/demos/electron/package.json
@@ -4,7 +4,10 @@
 	"version": "0.0.0",
 	"main": "main.js",
 	"dependencies": {
-		"electron": "~1.7.x",
-		"xlsx": "*"
+		"xlsx": "*",
+		"electron": "^9.0.2"
+	},
+	"scripts": {
+		"start": "electron ."
 	}
 }


### PR DESCRIPTION
Made in collaboration with @Shraddha2104 as part of the MLH fellowship.

This pull request updates the Electron SheetJS demo from `v1.7` to `v9.0.2`. 

Note that Electron now requires `nodeIntegration: true` in order to `require('XLSX')` in the renderer process. Read more about nodeIntegration security [here](https://www.electronjs.org/docs/tutorial/security#isolation-for-untrusted-content).

![image](https://user-images.githubusercontent.com/318295/83812949-051d7f80-a682-11ea-8d7a-7c35ee11845d.png)