### PR TITLE
Update React and React Native demos

### DIFF
--- a/demos/react/Makefile
+++ b/demos/react/Makefile
@@ -1,5 +1,5 @@
 .PHONY: react
-react: ## Simple server for react and clones
+react: init ## Simple server for react and clones
 	python -mSimpleHTTPServer
 
 .PHONY: next

--- a/demos/react/NOTES.md
+++ b/demos/react/NOTES.md
@@ -1,0 +1,22 @@
+# Additional Notes
+
+## Java, React Native, Gradle versions
+
+This demo was tested and runs with React Native 0.62.2, Java 11, and Gradle
+3.5.2. Running `make native` will invoke `native.sh`, which uses a fixed version
+of React Native 0.62.2 to build and run the demo.
+
+Make sure you have the correct version of Java (11) installed, since 0.62.2 might
+not work with newer versions of Java.
+
+## Common Issues
+
+```
+ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+```
+
+Add `export JAVA_HOME=<directory>`, replacing `<directory>` with the location of
+your Java install, to your `.bashrc` or any other shell that you are using.
+
+
+

--- a/demos/react/README.md
+++ b/demos/react/README.md
@@ -22,6 +22,10 @@ Other scripts in this demo show:
 - `preact` using the react compatibility library
 - `react-native` deployment for iOS and android
 
+Run `make react` to run the browser demo for React, or run `make next` to run
+the server-rendered demo using `next.js`.
+
+
 ## Internal State
 
 The simplest state representation is an array of arrays.  To avoid having the
@@ -109,6 +113,9 @@ writeFile(file, wbout, 'ascii').then((r)=>{/* :) */}).catch((e)=>{/* :( */});
 Note: for real app deployments, the `UIFileSharingEnabled` flag must be manually
 set in the iOS project `Info.plist` file.
 
+To run the React Native demo, run either `make ios` or `make android` while
+connected to a device or emulator.
+
 ## Other Demos
 
 #### Preact
@@ -125,3 +132,7 @@ step adds a small header that imports the library.  The import is not needed in
 deployments that use script tags to include the library.
 
 [![Analytics](https://ga-beacon.appspot.com/UA-36810333-1/SheetJS/js-xlsx?pixel)](https://github.com/SheetJS/js-xlsx)
+
+## Additional Notes
+
+Some additional notes can be found in [NOTES.md](NOTES.md).

--- a/demos/react/native.sh
+++ b/demos/react/native.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # xlsx.js (C) 2013-present  SheetJS -- http://sheetjs.com */
 if [ ! -e SheetJS ]; then
-	react-native init --version="0.53.3" SheetJS
+	react-native init --version="0.62.2" SheetJS
 	cd SheetJS
 	npm i -S xlsx react-native-table-component react-native-fs
 	cd -


### PR DESCRIPTION
This pull request updates the React Native version used in the demo from `0.53` to `0.62.2`. Previously, `0.53` was incompatible with newer versions of Java past Java 8. 

### Changes:
- Updated Makefile script `react` to depend on `init`
- Bumped React Native version to `0.62.2`
- Added some additional notes about running the demo and version requirements