### PR TITLE
Added test for CRLF newlines

### DIFF
--- a/test.js
+++ b/test.js
@@ -1958,6 +1958,10 @@ describe('CSV', function() {
 			assert.equal(get_cell(sheet, "C1").t, 's');
 			assert.equal(get_cell(sheet, "C1").v, '100');
 		});
+		it('should interpret CRLF newlines', function() {
+			var wb = X.read(new Buffer("sep=&\r\n1&2&3\r\n4&5&6"), {type: "buffer"});
+			assert.equal(wb.Sheets.Sheet1["!ref"], "A1:C2");
+		});
 		if(!browser || typeof cptable !== 'undefined') it('should honor codepage for binary strings', function() {
 			var data = "abc,def\nghi,j\xD3l";
 			[[1251, 'У'],[1252, 'Ó'], [1253, 'Σ'], [1254, 'Ó'], [1255, '׃'], [1256, 'س'], [10000, '”']].forEach(function(m) {


### PR DESCRIPTION
Test case for checking if CRLF `\r\n` newlines are parsed correctly.

(Bug was fixed in #2004, so test should pass)