### PR TITLE
decode_range returns same reference for s and e when input range is a single cell

### DIFF
--- a/bits/27_csfutils.js
+++ b/bits/27_csfutils.js
@@ -26,7 +26,7 @@ function encode_cell(cell/*:CellAddress*/)/*:string*/ {
 	for(; col; col=((col-1)/26)|0) s = String.fromCharCode(((col-1)%26) + 65) + s;
 	return s + (cell.r + 1);
 }
-function decode_range(range/*:string*/)/*:Range*/ { var x =range.split(":").map(decode_cell); return {s:x[0],e:x[x.length-1]}; }
+function decode_range(range/*:string*/)/*:Range*/ { var x =range.split(":"); return {s:decode_cell(x[0]),e:decode_cell(x[x.length-1])}; }
 /*# if only one arg, it is assumed to be a Range.  If 2 args, both are cell addresses */
 function encode_range(cs/*:CellAddrSpec|Range*/,ce/*:?CellAddrSpec*/)/*:string*/ {
 	if(typeof ce === 'undefined' || typeof ce === 'number') {

--- a/test.js
+++ b/test.js
@@ -768,6 +768,19 @@ describe('API', function() {
 		]);
 		if(assert.deepEqual) assert.deepEqual(data.A2, { l: { Target: 'https://123.com' }, v: 'url', t: 's' });
 	});
+	it('decode_range', function() {
+		var _c = "ABC", _r = "123", _C = "DEF", _R = "456";
+
+		var r = X.utils.decode_range(_c + _r + ":" + _C + _R);
+		assert(r.s != r.e);
+		assert.equal(r.s.c, X.utils.decode_col(_c)); assert.equal(r.s.r, X.utils.decode_row(_r));
+		assert.equal(r.e.c, X.utils.decode_col(_C)); assert.equal(r.e.r, X.utils.decode_row(_R));
+
+		r = X.utils.decode_range(_c + _r);
+		assert(r.s != r.e);
+		assert.equal(r.s.c, X.utils.decode_col(_c)); assert.equal(r.s.r, X.utils.decode_row(_r));
+		assert.equal(r.e.c, X.utils.decode_col(_c)); assert.equal(r.e.r, X.utils.decode_row(_r));
+	});
 });
 
 function coreprop(props) {


### PR DESCRIPTION
When calling `decode_range` with a single cell, ie: `xlsx.utils.decode_range('A1')`, you end up with an object where `s` and `e` are the same reference.  Therefore, if you modify `e.c` or `e.r`, it will appear as if `s.c` or `s.r` has also been affected and vice versa.  This code change ensures `s` and `e` are independent references so that they don't side-effect each other.