### PR TITLE
fix: change test to read string, not buffer

### DIFF
--- a/tests/core.js
+++ b/tests/core.js
@@ -1973,7 +1973,7 @@ describe('CSV', function() {
 			assert.equal(get_cell(sheet, "C1").v, '100');
 		});
 		it('should interpret CRLF newlines', function() {
-			var wb = X.read(new Buffer("sep=&\r\n1&2&3\r\n4&5&6"), {type: "buffer"});
+			var wb = X.read("sep=&\r\n1&2&3\r\n4&5&6", {type: "string"});
 			assert.equal(wb.Sheets.Sheet1["!ref"], "A1:C2");
 		});
 		if(!browser || typeof cptable !== 'undefined') it('should honor codepage for binary strings', function() {


### PR DESCRIPTION
The browser test `CSV > input > should interpret CRLF newlines` was throwing an error for buffer not being defined.

A quick fix was to read it as a `string` instead of a `buffer`.

This also passes the browser tests and the Sauce Labs tests.