### PR TITLE
Mark generated files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@ xlsx*.js    text eol=lf
 *.flow.js   text eol=lf
 
 docbits/*      linguist-documentation
-dist/*         linguist-generated=true
-xlsx.js        linguist-generated=true
-xlsxworker.js  linguist-generated=true
-tests/core.js  linguist-generated=true
+dist/*         linguist-generated=true binary
+xlsx.js        linguist-generated=true binary
+xlsxworker.js  linguist-generated=true binary
+tests/core.js  linguist-generated=true binary


### PR DESCRIPTION
This supresses local text diffs and prevents git from trying to automatically resolve merge conflicts within the files