### PR TITLE
Fix for #2136

### DIFF
--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -288,7 +288,7 @@ function write_ws_xml_cell(cell/*:Cell*/, ref, ws, opts/*::, idx, wb*/)/*:string
 }
 
 var parse_ws_xml_data = (function() {
-	var cellregex = /<(?:\w+:)?c[ >]/, rowregex = /<\/(?:\w+:)?row>/;
+	var cellregex = /<(?:\w+:)?c[ \/>]/, rowregex = /<\/(?:\w+:)?row>/;
 	var rregex = /r=["']([^"']*)["']/, isregex = /<(?:\w+:)?is>([\S\s]*?)<\/(?:\w+:)?is>/;
 	var refregex = /ref=["']([^"']*)["']/;
 	var match_v = matchtag("v"), match_f = matchtag("f");


### PR DESCRIPTION
## What this PR Addresses?
--------
Adds an escape slash to cell matcher Regex pattern to allow support for parsing short close tags for empty cells: 

```xml
<c/>
```
