### PR TITLE
Add support for configuring outlines to be above the detail row, or to left of detail column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,10 @@ In addition to the base sheet keys, worksheets also add:
   will write all cells in the merge range if they exist, so be sure that only
   the first cell (upper-left) in the range is set.
 
+- `ws['!outline']`: configure how outlines should behave.
+  Example: `{above: true}` - equivalent of unchecking the Excel option "Summary rows below detail".
+  `{left: true}` - equivalent of unchecking the Excel option "Summary option to the right of detail."
+
 - `ws['!protect']`: object of write sheet protection properties.  The `password`
   key specifies the password for formats that support password-protected sheets
   (XLSX/XLSB/XLS).  The writer uses the XOR obfuscation method.  The following

--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -114,6 +114,13 @@ function write_ws_xml_sheetpr(ws, wb, idx, opts, o) {
 		props.codeName = escapexml(cname);
 	}
 
+	if(ws && ws["!outline"]) {
+		var outlineprops = {summaryBelow:1, summaryRight:1};
+		if(ws["!outline"].above) outlineprops.summaryBelow = 0;
+		if(ws["!outline"].left) outlineprops.summaryRight = 0;
+		payload = (payload||"") + writextag('outlinePr', null, outlineprops);
+	}
+
 	if(!needed && !payload) return;
 	o[o.length] = (writextag('sheetPr', payload, props));
 }


### PR DESCRIPTION
This adds support for the following Excel feature (in the Group configuration):

![Screen Shot 2020-11-02 at 3 20 57 PMEST](https://user-images.githubusercontent.com/3769532/97923455-01268400-1d2c-11eb-94ae-ff7af1d9b574.png)

Allowing the following output:

<img width="447" alt="Screen Shot 2020-11-02 at 4 55 03 PMEST" src="https://user-images.githubusercontent.com/3769532/97923552-2b784180-1d2c-11eb-897d-5ecc0c14814a.png">

