### PR TITLE
Add option to force quotes around string values when exporting to csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -2201,15 +2201,16 @@ For the example sheet:
 As an alternative to the `writeFile` CSV type, `XLSX.utils.sheet_to_csv` also
 produces CSV output.  The function takes an options argument:
 
-| Option Name  |  Default | Description                                        |
-| :----------- | :------: | :------------------------------------------------- |
-|`FS`          |  `","`   | "Field Separator"  delimiter between fields        |
-|`RS`          |  `"\n"`  | "Record Separator" delimiter between rows          |
-|`dateNF`      |  FMT 14  | Use specified date format in string output         |
-|`strip`       |  false   | Remove trailing field separators in each record ** |
-|`blankrows`   |  true    | Include blank lines in the CSV output              |
-|`skipHidden`  |  false   | Skips hidden rows/columns in the CSV output        |
-|`forceQuotes` |  false   | Force quotes around fields                         |
+| Option Name              |  Default | Description                                        |
+| :----------------------- | :------: | :------------------------------------------------- |
+|`FS`                      |  `","`   | "Field Separator"  delimiter between fields        |
+|`RS`                      |  `"\n"`  | "Record Separator" delimiter between rows          |
+|`dateNF`                  |  FMT 14  | Use specified date format in string output         |
+|`strip`                   |  false   | Remove trailing field separators in each record ** |
+|`blankrows`               |  true    | Include blank lines in the CSV output              |
+|`skipHidden`              |  false   | Skips hidden rows/columns in the CSV output        |
+|`forceQuotes`             |  false   | Force quotes around fields                         |
+|`forceQuotesAroundString` |  false   | Force quotes around string fields                  |
 
 - `strip` will remove trailing commas from each line under default `FS/RS`
 - `blankrows` must be set to `false` to skip blank lines.

--- a/bits/90_utils.js
+++ b/bits/90_utils.js
@@ -99,7 +99,7 @@ function make_csv_row(sheet/*:Worksheet*/, r/*:Range*/, R/*:number*/, cols/*:Arr
 		else if(val.v != null) {
 			isempty = false;
 			txt = ''+(o.rawNumbers && val.t == "n" ? val.v : format_cell(val, null, o));
-			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
+			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes || (o.forceQuotesAroundString && val.t != "n")) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
 			if(txt == "ID") txt = '"ID"';
 		} else if(val.f != null && !val.F) {
 			isempty = false;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -630,6 +630,9 @@ export interface Sheet2CSVOpts extends DateNFOption {
     /** Force quotes around fields */
     forceQuotes?: boolean;
 
+    /** Force quotes around string fields */
+    forceQuotesAroundString?: boolean;
+
     /** if true, return raw numbers; if false, return formatted numbers */
     rawNumbers?: boolean;
 }

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -21422,7 +21422,7 @@ function make_csv_row(sheet/*:Worksheet*/, r/*:Range*/, R/*:number*/, cols/*:Arr
 		else if(val.v != null) {
 			isempty = false;
 			txt = ''+(o.rawNumbers && val.t == "n" ? val.v : format_cell(val, null, o));
-			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
+			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes || (o.forceQuotesAroundString && val.t != "n")) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
 			if(txt == "ID") txt = '"ID"';
 		} else if(val.f != null && !val.F) {
 			isempty = false;

--- a/xlsx.js
+++ b/xlsx.js
@@ -21291,7 +21291,7 @@ function make_csv_row(sheet, r, R, cols, fs, rs, FS, o) {
 		else if(val.v != null) {
 			isempty = false;
 			txt = ''+(o.rawNumbers && val.t == "n" ? val.v : format_cell(val, null, o));
-			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
+			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes || (o.forceQuotesAroundString && val.t != "n")) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
 			if(txt == "ID") txt = '"ID"';
 		} else if(val.f != null && !val.F) {
 			isempty = false;

--- a/xlsx.mini.flow.js
+++ b/xlsx.mini.flow.js
@@ -10311,7 +10311,7 @@ function make_csv_row(sheet/*:Worksheet*/, r/*:Range*/, R/*:number*/, cols/*:Arr
 		else if(val.v != null) {
 			isempty = false;
 			txt = ''+(o.rawNumbers && val.t == "n" ? val.v : format_cell(val, null, o));
-			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
+			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes || (o.forceQuotesAroundString && val.t != "n")) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
 			if(txt == "ID") txt = '"ID"';
 		} else if(val.f != null && !val.F) {
 			isempty = false;

--- a/xlsx.mini.js
+++ b/xlsx.mini.js
@@ -10205,7 +10205,7 @@ function make_csv_row(sheet, r, R, cols, fs, rs, FS, o) {
 		else if(val.v != null) {
 			isempty = false;
 			txt = ''+(o.rawNumbers && val.t == "n" ? val.v : format_cell(val, null, o));
-			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
+			for(var i = 0, cc = 0; i !== txt.length; ++i) if((cc = txt.charCodeAt(i)) === fs || cc === rs || cc === 34 || o.forceQuotes || (o.forceQuotesAroundString && val.t != "n")) {txt = "\"" + txt.replace(qreg, '""') + "\""; break; }
 			if(txt == "ID") txt = '"ID"';
 		} else if(val.f != null && !val.F) {
 			isempty = false;


### PR DESCRIPTION
This is very similar to [486f35b](https://github.com/SheetJS/sheetjs/commit/486f35b4cc59d53d5c046760fe98923ade9201ad) but quotes will be put only around string fields (and not numbers).

I have a client who explicitly requires this, not sure why...

I'm submitting this in case it can be useful to others.
