### PR TITLE
Fix:Non-mini xlsx.js missing "Root Entry" removal for proper ZIP parsing

### DIFF
--- a/bits/21_ziputils.js
+++ b/bits/21_ziputils.js
@@ -29,7 +29,7 @@ function safegetzipfile(zip, file/*:string*/) {
 	var k = zip.FullPaths || keys(zip.files);
 	var f = file.toLowerCase(), g = f.replace(/\//g,'\\');
 	for(var i=0; i<k.length; ++i) {
-		var n = k[i].toLowerCase();
+		var n = (zip.FullPaths ? k[i].replace(/^Root Entry[\/]/,"") : k[i]).toLowerCase();
 		if(f == n || g == n) return zip.files[k[i]];
 	}
 	return null;


### PR DESCRIPTION
Fixes #1736