### PR TITLE
Fix TypeError when styles don't have NumberFmt

### DIFF
--- a/bits/47_styxml.js
+++ b/bits/47_styxml.js
@@ -318,7 +318,7 @@ function parse_cellXfs(t, styles, opts) {
 					xf[cellXF_uint[i]] = parseInt(xf[cellXF_uint[i]], 10);
 				for(i = 0; i < cellXF_bool.length; ++i) if(xf[cellXF_bool[i]])
 					xf[cellXF_bool[i]] = parsexmlbool(xf[cellXF_bool[i]]);
-				if(xf.numFmtId > 0x188) {
+				if(styles.NumberFmt && xf.numFmtId > 0x188) {
 					for(i = 0x188; i > 0x3c; --i) if(styles.NumberFmt[xf.numFmtId] == styles.NumberFmt[i]) { xf.numFmtId = i; break; }
 				}
 				styles.CellXf.push(xf); break;


### PR DESCRIPTION

<img width="1091" alt="xlsx-debug" src="https://user-images.githubusercontent.com/9206414/123214209-80eea200-d4f9-11eb-86b7-51581e4aebf4.png">


reproduction: https://codesandbox.io/s/red-worker-yf019?file=/src/index.js