### PR TITLE
Issue #1300 fix: fuzzydate strict date option regex

### DIFF
--- a/bits/20_jsutils.js
+++ b/bits/20_jsutils.js
@@ -130,8 +130,33 @@ function fuzzynum(s/*:string*/)/*:number*/ {
 	if(!isNaN(v = Number(ss))) return v / wt;
 	return v;
 }
-function fuzzydate(s/*:string*/)/*:Date*/ {
+
+// date regex reference - https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s04.html
+// matches mm/dd/yy, mm/dd/yyyy, dd/mm/yy, dd/mm/yyyy
+const STRICT_DATE_REGEX = [
+	"^(?:(1[0-2]|0[1-9])\\.(3[01]|[12][0-9]|0[1-9])|(3[01]|[12][0-9]|0[1-9])\\.(1[0-2]|0[1-9]))\\.([0-2][0-9]{3}|[0-9]{2})$", 
+	"^(?:(1[0-2]|0[1-9])\/(3[01]|[12][0-9]|0[1-9])|(3[01]|[12][0-9]|0[1-9])\/(1[0-2]|0[1-9]))\/([0-2][0-9]{3}|[0-9]{2})$",
+	"^(?:(1[0-2]|0[1-9])-(3[01]|[12][0-9]|0[1-9])|(3[01]|[12][0-9]|0[1-9])-(1[0-2]|0[1-9]))-([0-2][0-9]{3}|[0-9]{2})$",
+	"^(?:(1[0-2]|0[1-9])\\.(3[01]|[12][0-9]|0[1-9])|(3[01]|[12][0-9]|0[1-9])\\.(1[0-2]|0[1-9]))\\.([0-2][0-9]{3}|[0-9]{2})$",
+	"^(?:(1[0-2]|0[1-9])\/(3[01]|[12][0-9]|0[1-9])|(3[01]|[12][0-9]|0[1-9])\/(1[0-2]|0[1-9]))\/([0-2][0-9]{3}|[0-9]{2})$",
+	"^(?:(1[0-2]|0[1-9])-(3[01]|[12][0-9]|0[1-9])|(3[01]|[12][0-9]|0[1-9])-(1[0-2]|0[1-9]))-([0-2][0-9]{3}|[0-9]{2})$"
+	];
+
+function fuzzydate(s/*:string*/, strictDate = false/*boolean*/)/*:Date*/ {
 	var o = new Date(s), n = new Date(NaN);
+
+	if(strictDate) {
+		STRICT_DATE_REGEX.map(regex => {
+			const matchStr = s.match(regex)
+
+			if(matchStr){
+				return o;
+			};
+	  	});
+
+		return n;
+	}
+
 	var y = o.getYear(), m = o.getMonth(), d = o.getDate();
 	if(isNaN(d)) return n;
 	if(y < 0 || y > 8099) return n;

--- a/bits/40_harb.js
+++ b/bits/40_harb.js
@@ -883,7 +883,7 @@ var PRN = (function() {
 			else if(s == "TRUE") { cell.t = 'b'; cell.v = true; }
 			else if(s == "FALSE") { cell.t = 'b'; cell.v = false; }
 			else if(!isNaN(v = fuzzynum(s))) { cell.t = 'n'; if(o.cellText !== false) cell.w = s; cell.v = v; }
-			else if(!isNaN(fuzzydate(s).getDate()) || _re && s.match(_re)) {
+			else if(!isNaN(fuzzydate(s, o.strictDate).getDate()) || _re && s.match(_re)) {
 				cell.z = o.dateNF || SSF._table[14];
 				var k = 0;
 				if(_re && s.match(_re)){ s=dateNF_fix(s, o.dateNF, (s.match(_re)||[])); k=1; }


### PR DESCRIPTION
Hey! This fix refers to [issue #1300](https://github.com/SheetJS/sheetjs/issues/1300)

I made changes to two of the files to include regex options to parse dates in the following formats:
- mm dd yyyy 
- mm dd yy
- dd mm yyyy
- dd mm yy

All the aforementioned date formats use the separators `. or - or /`, e.g.:
- dd-mm-yy
- dd.mm.yy
- dd/mm/yy

This can be activated using the strictDate option in the fuzzydate function which is set to `false` by default.

Let me know whether this solution is what you were looking for!