### PR TITLE
Use named define for requireJS

### DIFF
--- a/bits/99_footer.js
+++ b/bits/99_footer.js
@@ -3,7 +3,7 @@
 /*:: declare var define:any; */
 if(typeof exports !== 'undefined') make_xlsx_lib(exports);
 else if(typeof module !== 'undefined' && module.exports) make_xlsx_lib(module.exports);
-else if(typeof define === 'function' && define.amd) define(function() { if(!XLSX.version) make_xlsx_lib(XLSX); return XLSX; });
+else if(typeof define === 'function' && define.amd) define('xlsx-dist', function() { if(!XLSX.version) make_xlsx_lib(XLSX); return XLSX; });
 else make_xlsx_lib(XLSX);
 /*exported XLS, ODS */
 var XLS = XLSX, ODS = XLSX;


### PR DESCRIPTION
Two benefits:
    
* Helps avoid with mismatched anonymous errors

ref: https://requirejs.org/docs/errors.html#mismatch
 
* Allows for uglification in the demo