### PR TITLE
Field separator override in parser

### DIFF
--- a/bits/40_harb.js
+++ b/bits/40_harb.js
@@ -868,6 +868,7 @@ var PRN = (function() {
 			}
 			else sep = guess_sep(str.slice(0,1024));
 		}
+		else if(o && o.FS) sep = o.FS;
 		else sep = guess_sep(str.slice(0,1024));
 		var R = 0, C = 0, v = 0;
 		var start = 0, end = 0, sepcc = sep.charCodeAt(0), instr = false, cc=0, startcc=str.charCodeAt(0);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -163,6 +163,9 @@ export interface ParsingOptions extends CommonOptions {
     /** Override default date format (code 14) */
     dateNF?: string;
 
+    /** Field Separator ("Delimiter" override) */
+    FS?: string;
+
     /**
      * If >0, read the first sheetRows rows
      * @default 0


### PR DESCRIPTION
Fixes #2239 

Adds FS option in read method to override delimiter when necessary. 