### PR TITLE
issue #2460

### DIFF
--- a/bits/90_utils.js
+++ b/bits/90_utils.js
@@ -16,7 +16,10 @@ function make_json_row(sheet/*:Worksheet*/, r/*:Range*/, R/*:number*/, cols/*:Ar
 	if(!dense || sheet[R]) for (var C = r.s.c; C <= r.e.c; ++C) {
 		var val = dense ? sheet[R][C] : sheet[cols[C] + rr];
 		if(val === undefined || val.t === undefined) {
-			if(defval === undefined) continue;
+			if(defval === undefined) { 
+				if (R == 1 && o.keeporder) row[hdr[C]] = null; 
+				continue; 
+			}
 			if(hdr[C] != null) { row[hdr[C]] = defval; }
 			continue;
 		}

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -22201,7 +22201,10 @@ function make_json_row(sheet/*:Worksheet*/, r/*:Range*/, R/*:number*/, cols/*:Ar
 	if(!dense || sheet[R]) for (var C = r.s.c; C <= r.e.c; ++C) {
 		var val = dense ? sheet[R][C] : sheet[cols[C] + rr];
 		if(val === undefined || val.t === undefined) {
-			if(defval === undefined) continue;
+			if(defval === undefined) { 
+				if (R == 1 && o.keeporder) row[hdr[C]] = null; 
+				continue; 
+			}
 			if(hdr[C] != null) { row[hdr[C]] = defval; }
 			continue;
 		}

--- a/xlsx.js
+++ b/xlsx.js
@@ -22073,7 +22073,10 @@ function make_json_row(sheet, r, R, cols, header, hdr, dense, o) {
 	if(!dense || sheet[R]) for (var C = r.s.c; C <= r.e.c; ++C) {
 		var val = dense ? sheet[R][C] : sheet[cols[C] + rr];
 		if(val === undefined || val.t === undefined) {
-			if(defval === undefined) continue;
+			if(defval === undefined) { 
+				if (R == 1 && o.keeporder) row[hdr[C]] = null; 
+				continue; 
+			}
 			if(hdr[C] != null) { row[hdr[C]] = defval; }
 			continue;
 		}


### PR DESCRIPTION
The PR #2461 has been redone here to pass the automatic rebase test.
In case this PR is approved and merged, I can prepare a follow-up change for the [json options](https://github.com/SheetJS/sheetjs#json) documentation, adding a line in the table for the new `keeporder` option, very similarly to the existing `defvalue`.