### PR TITLE
avoid utf-8 buffer re-decoding

### DIFF
--- a/bits/40_harb.js
+++ b/bits/40_harb.js
@@ -947,7 +947,7 @@ var PRN = (function() {
 			default: throw new Error("Unrecognized type " + opts.type);
 		}
 		if(bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) str = utf8read(str.slice(3));
-		else if(opts.type != 'string' && opts.codepage == 65001) str = utf8read(str);
+		else if(opts.type != 'string' && opts.type != 'buffer' && opts.codepage == 65001) str = utf8read(str);
 		else if((opts.type == 'binary') && typeof cptable !== 'undefined' && opts.codepage)  str = cptable.utils.decode(opts.codepage, cptable.utils.encode(28591,str));
 		if(str.slice(0,19) == "socialcalc:version:") return ETH.to_sheet(opts.type == 'string' ? str : utf8read(str), opts);
 		return prn_to_sheet_str(str, opts);


### PR DESCRIPTION
Related to [this issue](https://github.com/SheetJS/sheetjs/issues/2476), fix suggested by @SheetJSDev.