### PR TITLE
More restrictive fuzzydate

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -2873,11 +2873,16 @@ function fuzzydate(s) {
 	var o = new Date(s), n = new Date(NaN);
 	var y = o.getYear(), m = o.getMonth(), d = o.getDate();
 	if(isNaN(d)) return n;
-	if(y < 0 || y > 8099) return n;
-	if((m > 0 || d > 1) && y != 101) return o;
-	if(s.toLowerCase().match(/jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec/)) return o;
-	if(s.match(/[^-0-9:,\/\\]/)) return n;
-	return o;
+	if(s.toLowerCase().match(/jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec/)){
+		if(y < 0 || y > 8099) return n;
+		if((m > 0 || d > 1) && y != 101) return o;
+		return n;
+	} else {
+		if(s.replace(/\s+/g,'').length > 10) return n;
+		var dotsep = s.split(".").length-1, slashsep = s.split("/").length-1, dashsep = s.split("-").length-1;
+		if(dotsep+slashsep+dashsep == 2 && ((!slashsep && !dashsep) || (!dotsep && !dashsep) || (!dotsep && !slashsep))) return o;
+	}
+	return n;
 }
 
 var safe_split_regex = "abacaba".split(/(:?b)/i).length == 5;


### PR DESCRIPTION
This change makes the fuzzydate function more restrictive. The changes are:

- For dates without a month name, only dates with **two** valid separators(`/` `-` `.`) are allowed.
ex. `1/2` is no longer assumed to be a date where as `1/2/0` is acceptable. 
dates with spaces as a separator are not assumed to be dates such as `1 2 0` 
Note: `1 / 2 / 0` is acceptable
Also fixes `AUD 76.09` from a [comment ](https://github.com/SheetJS/sheetjs/issues/1636#issuecomment-557643678) on issue #1636  will no longer be parsed as a date.

- Values such as `05.030.2713` will no longer be accepted as dates because of the month having 3 digits (a total of > 10 digits) #2485 

I have seen many issues created over fuzzydate and while raw parsing is a workaround, many people want other numeric values preserved and by default. This is a proposed solution by dropping support for mm/dd, mm/yyyy, mm.yyyy etc. 

I assume support for dates with a space separator is necessary so let me know if it's worth continuing in this direction. An issue not addressed by this solution is the automatic date conversion of values with two decimal points such as: `3.5.2`. Values like these are often used for software versioning. I would prefer not to have to use decimal separator with dates as it's much less common but was curious if any other spreadsheet software uses this standard. 



