### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2208,7 +2208,7 @@ Parse options are described in the [Parsing Options](#parsing-options) section.
 `XLSX.writeFile(wb, filename, write_opts)` attempts to write `wb` to `filename`.
 In browser-based environments, it will attempt to force a client-side download.
 
-`XLSX.writeFileAsync(wb, filename, o, cb)` attempts to write `wb` to `filename`.
+`XLSX.writeFileAsync(filename, wb, o, cb)` attempts to write `wb` to `filename`.
 If `o` is omitted, the writer will use the third argument as the callback.
 
 `XLSX.stream` contains a set of streaming write functions.


### PR DESCRIPTION
- Type definition differs from README
- tested and works as tyoe defines

```
type CBFunc = () => void;
export function writeFileAsync(filename: string, data: WorkBook, opts: WritingOptions | CBFunc, cb?: CBFunc): any;
```