### PR TITLE
Fixed 'ReadableStream' function example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,7 +1075,7 @@ async function process_RS(stream) {
   const out = new Uint8Array(buffers.reduce((acc, v) => acc + v.length, 0));
 
   let off = 0;
-  for(const u8 of arr) {
+  for(const u8 of buffers) {
     out.set(u8, off);
     off += u8.length;
   }
@@ -1085,7 +1085,7 @@ async function process_RS(stream) {
 
 const data = await process_RS(stream);
 /* data is Uint8Array */
-const workbook = XLSX.read(data);
+const workbook = XLSX.read(data, {type: "array"});
 ```
 
 </details>


### PR DESCRIPTION
The function as it is written doesn't work, replaced reference to 'arr' with 'buffers' and added '{type: "array"}' to XLSX.read arguments.