### PR TITLE
docs: replace all `git.io` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2191,7 +2191,7 @@ an apostrophe `'`, consistent with Excel's formula bar display.
 
 `XLSX.version` is the version of the library (added by the build script).
 
-`XLSX.SSF` is an embedded version of the [format library](https://git.io/ssf).
+`XLSX.SSF` is an embedded version of the [format library](https://github.com/SheetJS/ssf).
 
 ### Parsing functions
 

--- a/demos/oldie/index.html
+++ b/demos/oldie/index.html
@@ -40,7 +40,7 @@ function doit(type, fn, dl) {
 <b>Compatibility notes:</b>
 - Editable table leverages the HTML5 contenteditable feature, supported in most browsers.
 - IE6-9 requires ActiveX to upload files and ActiveX or Flash to download files.
-- iOS Safari file download may not work. <a href="http://git.io/ios_save">This is a known issue</a>.
+- iOS Safari file download may not work. <a href="https://github.com/eligrey/FileSaver.js/issues/12">This is a known issue</a>.
 
 <b>Update Spreadsheet:</b> (submit file to update table; file parsed in browser)
 <input type="file" id="file" />

--- a/docbits/40_interface.md
+++ b/docbits/40_interface.md
@@ -4,7 +4,7 @@
 
 `XLSX.version` is the version of the library (added by the build script).
 
-`XLSX.SSF` is an embedded version of the [format library](https://git.io/ssf).
+`XLSX.SSF` is an embedded version of the [format library](https://github.com/SheetJS/ssf).
 
 ### Parsing functions
 

--- a/misc/docs/README.md
+++ b/misc/docs/README.md
@@ -2062,7 +2062,7 @@ an apostrophe `'`, consistent with Excel's formula bar display.
 
 `XLSX.version` is the version of the library (added by the build script).
 
-`XLSX.SSF` is an embedded version of the [format library](https://git.io/ssf).
+`XLSX.SSF` is an embedded version of the [format library](https://github.com/SheetJS/ssf).
 
 ### Parsing functions
 


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace all `git.io/ssf` with `https://github.com/SheetJS/ssf`.