### PR TITLE
Xspreadsheet demo, number cell type detection improvments

### DIFF
--- a/demos/xspreadsheet/xlsxspread.js
+++ b/demos/xspreadsheet/xlsxspread.js
@@ -91,8 +91,8 @@ function xtos(sdata) {
         if (!cellText) {
           cellText = "";
           type = "z";
-        } else if (!isNaN(parseFloat(cellText))) {
-          cellText = parseFloat(cellText);
+        } else if (!isNaN(Number(cellText))) {
+          cellText = Number(cellText);
           type = "n";
         } else if (cellText.toLowerCase() === "true" || cellText.toLowerCase() === "false") {
           cellText = Boolean(cellText);


### PR DESCRIPTION
Hi,

I just take notice that `parseFloat()` wasn't optimal due to incorrect guesses for strings beginning with numbers but containing other characters.

For examples :
```js
//Integer+string
parseFloat('1x'); // => 1
Number('1x'); // => NaN
//Hexadecimal (parseFloat doesn't understand parse
parseFloat('0x10'); // => 0
Number('0x10'); // => 16
```

Note: This is a slight improvement but we might need further tests for some specific cases (described below) because I don't really know how it will react, but globally with `Number()` we get less data loss

- empty/whitspace strings 
```js
parseFloat(''); // => NaN
Number(''); // => 0
parseFloat(' \r\n\t'); // => NaN
Number(' \r\n\t'); // => 0
```
- some specific string like "Infinity"
```js
parseFloat('Infinity'); // => NaN
Number('Infinity'); // => Infinity
```
- booleans
```js
parseFloat(false); // => NaN
Number(false); // => 0
```
