### PR TITLE
Export choose_fmt

### DIFF
--- a/packages/ssf/ssf.js
+++ b/packages/ssf/ssf.js
@@ -927,6 +927,7 @@ function choose_fmt(f, v) {
 	}
 	return [l, ff];
 }
+SSF.choose_format = choose_fmt;	
 function format(fmt,v,o) {
 	if(o == null) o = {};
 	var sfmt = "";

--- a/packages/ssf/ssf.js
+++ b/packages/ssf/ssf.js
@@ -927,7 +927,6 @@ function choose_fmt(f, v) {
 	}
 	return [l, ff];
 }
-SSF.choose_format = choose_fmt;	
 function format(fmt,v,o) {
 	if(o == null) o = {};
 	var sfmt = "";
@@ -972,6 +971,8 @@ SSF.load_table = function load_table(tbl) {
 };
 SSF.init_table = init_table;
 SSF.format = format;
+SSF.choose_format = choose_fmt;
+SSF.isgeneral = isgeneral;
 };
 make_ssf(SSF);
 /*global module */

--- a/packages/ssf/ssf.js
+++ b/packages/ssf/ssf.js
@@ -972,7 +972,6 @@ SSF.load_table = function load_table(tbl) {
 SSF.init_table = init_table;
 SSF.format = format;
 SSF.choose_format = choose_fmt;
-SSF.isgeneral = isgeneral;
 };
 make_ssf(SSF);
 /*global module */


### PR DESCRIPTION

in order to implement format with limited width as described here (https://github.com/SheetJS/sheetjs/issues/2689) externally we need to use "choose_fmt" and "isgeneral".


