### PR TITLE
feat(98_esmxport): add esm default export

### DIFF
--- a/misc/98_esmxport.js
+++ b/misc/98_esmxport.js
@@ -18,3 +18,22 @@ export {
 	SSF,
 	CFB
 };
+export default {
+	parse_xlscfb,
+	parse_zip,
+	readSync as read,
+	readFileSync as readFile,
+	readFileSync,
+	writeSync as write,
+	writeFileSync as writeFile,
+	writeFileSync,
+	writeFileAsync,
+	writeSyncXLSX as writeXLSX,
+	writeFileSyncXLSX as writeFileXLSX,
+	utils,
+	set_fs,
+	set_cptable,
+	__stream as stream,
+	SSF,
+	CFB
+}


### PR DESCRIPTION
Recently I upgraded the xlsx version of the project from 0.15.6=>0.18.5, which caused the project to report an error, and I found that the previous project used the following syntax
```
import xlsx from 'xlsx';
...
xlsx.read(...)
...
```
This upgrade causes the failure to feel still not very good, should you consider adding a default export?
Thanks for the answer