### PR TITLE
add `display` attribute to hyperlinks

### DIFF
--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -299,7 +299,10 @@ function write_ws_xml_cell(cell/*:Cell*/, ref, ws, opts/*::, idx, wb*/)/*:string
 		var ff = cell.F && cell.F.slice(0, ref.length) == ref ? {t:"array", ref:cell.F} : null;
 		v = writextag('f', escapexml(cell.f), ff) + (cell.v != null ? v : "");
 	}
-	if(cell.l) ws['!links'].push([ref, cell.l]);
+	if(cell.l) {
+		cell.l.display = escapexml(vv);
+		ws['!links'].push([ref, cell.l]);
+	}
 	if(cell.D) o.cm = 1;
 	return writextag('c', v, o);
 }
@@ -609,6 +612,7 @@ function write_ws_xml(idx/*:number*/, opts, wb/*:Workbook*/, rels)/*:string*/ {
 			}
 			if((relc = l[1].Target.indexOf("#")) > -1) rel.location = escapexml(l[1].Target.slice(relc+1));
 			if(l[1].Tooltip) rel.tooltip = escapexml(l[1].Tooltip);
+			rel.display = l[1].display;
 			o[o.length] = writextag("hyperlink",null,rel);
 		});
 		o[o.length] = "</hyperlinks>";


### PR DESCRIPTION
# Issue

This resolves an import issue with Google Sheets where the cell's text content is lost. On import, Sheets converts hyperlinks to a `HYPERLINK` formula. When the `<hyperlink>` lacks a `display` attribute, it drops the text content of the cell and replaces it with the location of the hyperlink.

## Example
An XLSX with the following `<hyperlink>`:

```
<hyperlink ref="E2" location="'Sheet1'!A3"/>
```

When imported into Google Sheets, `E2` becomes:

```
=HYPERLINK("#gid=1368866318&range=A3","#gid=1368866318&range=A3")
```


# Change

This change automatically sets the `display` attribute of a `<hyperlink>` based on the cell's value.

I don't see much of a reason to expose the `display` attribute in the API like the `Tooltip` property, since it "should" always be the cell's value.

I've only made this change to the XLSX format renderer. Contributions for XLSB and other formats, tests, and feedback on my implementation are welcome.


# Quirks Observed

1. When opening an XLSX in Excel generated by this package (before this PR), Excel natively sets the `display` attribute of all `<hyperlink>`s on save, even if they previously did not have this attribute.

2. Excel will render the underlying text content of the cell and ignores the `display` attribute of the `<hyperlink>`, even if they differ. Google Sheets clobbers the text content and only uses the `display` attribute to set the `HYPERLINK` formula's link label.