### PR TITLE
Add `types` to subpath exports in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,22 +28,27 @@
 	"exports": {
 		".": {
 			"import": "./xlsx.mjs",
-			"require": "./xlsx.js"
+			"require": "./xlsx.js",
+			"types": "./types/index.d.ts"
 		},
 		"./xlsx.mjs": {
-			"import": "./xlsx.mjs"
+			"import": "./xlsx.mjs",
+			"types": "./types/index.d.ts"
 		},
 		"./dist/xlsx.zahl": {
 			"import": "./dist/xlsx.zahl.mjs",
-			"require": "./dist/xlsx.zahl.js"
+			"require": "./dist/xlsx.zahl.js",
+			"types": "./types/index.d.ts"
 		},
 		"./dist/cpexcel": {
 			"import": "./dist/cpexcel.full.mjs",
-			"require": "./dist/cpexcel.js"
+			"require": "./dist/cpexcel.js",
+			"types": "./types/index.d.ts"
 		},
 		"./dist/cpexcel.full": {
 			"import": "./dist/cpexcel.full.mjs",
-			"require": "./dist/cpexcel.js"
+			"require": "./dist/cpexcel.js",
+			"types": "./types/index.d.ts"
 		}
 	},
 	"browser": {


### PR DESCRIPTION
When a project's `tsconfig.json` is configured to use ECMAScript modules and has `strict` or `noImplicitAny` set to `true`, TypeScript complains about being unable to find `xlsx`'s declaration file:
```
TSError: ⨯ Unable to compile TypeScript:
src/index.ts:1:23 - error TS7016: Could not find a declaration file for module 'xlsx'. '<OMITTED>/node_modules/xlsx/xlsx.mjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/xlsx` if it exists or add a new declaration (.d.ts) file containing `declare module 'xlsx';`

1 import * as XLSX from 'xlsx';
```

`tsconfig.json`

```json
{
  "compilerOptions": {
    "target": "ES2015",
    "module": "Node16",
    "outDir": "./build",
    "sourceMap": true,
    "allowJs": true,
    "strict": true
  },
  "include": ["./src/**/*"]
}
```

The change in this PR should resolve the issue.