### PR TITLE
Fix for Issue 2752 where blankrows:true skips first blank line

### DIFF
--- a/bits/27_csfutils.js
+++ b/bits/27_csfutils.js
@@ -173,7 +173,11 @@ function sheet_add_aoa(_ws/*:?Worksheet*/, data/*:AOA*/, opts/*:?any*/)/*:Worksh
 			}
 		}
 	}
-	if(range.s.c < 10000000) ws['!ref'] = encode_range(range);
+	if (range.s.c < 10000000) {
+        if (range.s.c > _C) range.s.c = _C;
+        if (range.s.r > _R) range.s.r = _R;
+        ws["!ref"] = encode_range(range);
+    }
 	return ws;
 }
 function aoa_to_sheet(data/*:AOA*/, opts/*:?any*/)/*:Worksheet*/ { return sheet_add_aoa(null, data, opts); }

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -4449,7 +4449,11 @@ function sheet_add_aoa(_ws/*:?Worksheet*/, data/*:AOA*/, opts/*:?any*/)/*:Worksh
 			}
 		}
 	}
-	if(range.s.c < 10000000) ws['!ref'] = encode_range(range);
+	if (range.s.c < 10000000) {
+        if (range.s.c > _C) range.s.c = _C;
+        if (range.s.r > _R) range.s.r = _R;
+        ws["!ref"] = encode_range(range);
+    }
 	return ws;
 }
 function aoa_to_sheet(data/*:AOA*/, opts/*:?any*/)/*:Worksheet*/ { return sheet_add_aoa(null, data, opts); }

--- a/xlsx.js
+++ b/xlsx.js
@@ -4364,7 +4364,11 @@ function sheet_add_aoa(_ws, data, opts) {
 			}
 		}
 	}
-	if(range.s.c < 10000000) ws['!ref'] = encode_range(range);
+	if (range.s.c < 10000000) {
+        if (range.s.c > _C) range.s.c = _C;
+        if (range.s.r > _R) range.s.r = _R;
+        ws["!ref"] = encode_range(range);
+    }
 	return ws;
 }
 function aoa_to_sheet(data, opts) { return sheet_add_aoa(null, data, opts); }


### PR DESCRIPTION
This PR tries to solve #2752 which is also mentioned in PR #2776 but it did not pass all tests of a PR as set by SheetJS.

This PR consists of two commits:
1. Same code as mentioned in https://github.com/SheetJS/sheetjs/issues/2752#issuecomment-1203205189 
2. After running `yarn lint`, two other files were also updated, namely `xlsx.js` and `xlsx.flow.js`, which are also committed in this PR. These were missing in the code changes of PR #2776 .

Let's hope this time all tests cases are passed!