### PR TITLE
fix(types): Add FS in WritingOptions type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -282,6 +282,14 @@ export interface WritingOptions extends CommonOptions, SheetOption {
 
     /** Base64 encoding of NUMBERS base for exports */
     numbers?: string;
+
+    /**
+     * Separator for the data fields in the exported file.
+     * Use this character to distinguish and separate information fields.
+     * @example
+     * FS: ','
+     *//** Separator  */
+    FS?: string;
 }
 
 /** Workbook Object */


### PR DESCRIPTION
In my project I also need to make the CSV available, however the default separator is comma `,` and for my project I need it to be semicolon `;`.

Using FS in WritingOptions is working in my project, but it is displaying a type error.

I added the FS that accepts a string in the WritingOptions type.